### PR TITLE
feat: start protocol schema extraction wave

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+      - name: Run schema validation
+        run: python scripts/validate_schemas.py
+      - name: Run tests
+        run: python -m pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -4,4 +4,18 @@ AXP protocol specifications, schemas, and compatibility notes.
 
 ## Status
 
-Repository bootstrap in progress.
+Wave 1 extraction in progress.
+
+## Included in Wave 1
+
+- `schemas/protocol/message.envelope.v2.json`
+- `schemas/protocol/message.delivery.v1.json`
+- schema validation script and CI gate
+
+## Development
+
+```bash
+python -m pip install -e ".[dev]"
+python scripts/validate_schemas.py
+pytest
+```

--- a/axme_spec/__init__.py
+++ b/axme_spec/__init__.py
@@ -1,0 +1,1 @@
+"""AXP specification package metadata."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["hatchling>=1.25.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "axme-spec"
+version = "0.1.0"
+description = "Canonical Axme protocol specifications and schemas."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=9.0.0,<10.0.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["axme_spec"]

--- a/schemas/protocol/message.delivery.v1.json
+++ b/schemas/protocol/message.delivery.v1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/protocol/message.delivery.v1.json",
+  "title": "MessageDeliveryV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ack"
+  ],
+  "properties": {
+    "ack": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "delivered",
+        "read",
+        "processed",
+        "failed"
+      ]
+    },
+    "failure_reason": {
+      "type": "string",
+      "maxLength": 2000
+    },
+    "accepted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "delivered_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "read_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "processed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "failed_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/protocol/message.envelope.v2.json
+++ b/schemas/protocol/message.envelope.v2.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/protocol/message.envelope.v2.json",
+  "title": "MessageEnvelopeV2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "message_id",
+    "from",
+    "to",
+    "content_kind",
+    "payload",
+    "trace"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "v2"
+    },
+    "message_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "thread_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uuid"
+    },
+    "from": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "to": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": {
+        "type": "string",
+        "minLength": 3,
+        "maxLength": 255
+      }
+    },
+    "content_kind": {
+      "type": "string",
+      "enum": [
+        "text",
+        "intent",
+        "media",
+        "system"
+      ]
+    },
+    "semantic_type": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+(?:\\.[a-z0-9_]+){2,}\\.v[0-9]+$"
+    },
+    "schema_ref": {
+      "type": "string",
+      "maxLength": 512
+    },
+    "schema_mode": {
+      "type": "string",
+      "enum": [
+        "none",
+        "warn",
+        "enforce"
+      ]
+    },
+    "payload": {
+      "type": "object"
+    },
+    "attachments": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "upload_id"
+        ],
+        "properties": {
+          "upload_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "mime_type": {
+            "type": "string",
+            "minLength": 3
+          }
+        }
+      }
+    },
+    "delivery": {
+      "$ref": "https://axme.dev/schemas/protocol/message.delivery.v1.json"
+    },
+    "idempotency_key": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 128
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "correlation_id"
+      ],
+      "properties": {
+        "correlation_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "causation_id": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "string",
+          "number",
+          "boolean",
+          "null"
+        ]
+      }
+    }
+  }
+}

--- a/scripts/validate_schemas.py
+++ b/scripts/validate_schemas.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def load_schema_documents(root: Path) -> list[dict]:
+    docs: list[dict] = []
+    for schema_path in sorted((root / "schemas").rglob("*.json")):
+        docs.append(json.loads(schema_path.read_text(encoding="utf-8")))
+    return docs
+
+
+def validate_schema_documents(root: Path) -> list[str]:
+    errors: list[str] = []
+    ids: set[str] = set()
+    for schema_path in sorted((root / "schemas").rglob("*.json")):
+        try:
+            doc = json.loads(schema_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"{schema_path}: invalid json ({exc})")
+            continue
+
+        schema_id = doc.get("$id")
+        if not schema_id:
+            errors.append(f"{schema_path}: missing $id")
+            continue
+        if schema_id in ids:
+            errors.append(f"{schema_path}: duplicate $id={schema_id}")
+        ids.add(schema_id)
+
+    return errors
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    errors = validate_schema_documents(root)
+    if errors:
+        print("schema validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("schema validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_schemas.py
+++ b/tests/test_validate_schemas.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.validate_schemas import validate_schema_documents
+
+
+def test_schema_documents_are_valid() -> None:
+    root = Path(__file__).resolve().parents[1]
+    errors = validate_schema_documents(root)
+    assert errors == []


### PR DESCRIPTION
## Summary
- extract initial protocol schemas into `axme-spec` (`message.envelope.v2`, `message.delivery.v1`)
- add schema validation script and unit test gate
- add CI workflow for validation and tests

## Test plan
- [x] `/.venv/bin/python -m pip install -e \".[dev]\"`
- [x] `/.venv/bin/python scripts/validate_schemas.py`
- [x] `/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)