### PR TITLE
feat: expand protocol schemas and governance docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,25 @@ AXP protocol specifications, schemas, and compatibility notes.
 
 ## Status
 
-Wave 1 extraction in progress.
+Wave 2 extraction in progress.
 
-## Included in Wave 1
+## Included through Wave 2
 
-- `schemas/protocol/message.envelope.v2.json`
-- `schemas/protocol/message.delivery.v1.json`
-- schema validation script and CI gate
+- Protocol schemas:
+  - `schemas/protocol/intent.ask.v1.json`
+  - `schemas/protocol/intent.envelope.v1.json`
+  - `schemas/protocol/intent.error.v1.json`
+  - `schemas/protocol/intent.reply.v1.json`
+  - `schemas/protocol/intent.status.v1.json`
+  - `schemas/protocol/message.delivery.v1.json`
+  - `schemas/protocol/message.envelope.v2.json`
+  - `schemas/protocol/message.envelope.v3.json`
+- Governance docs:
+  - `docs/public-api-schema-index.md`
+  - `docs/schema-versioning-rules.md`
+  - `docs/protocol-error-status-model.md`
+  - `docs/idempotency-correlation-rules.md`
+- Schema validation script, tests, and CI gate
 
 ## Development
 

--- a/docs/idempotency-correlation-rules.md
+++ b/docs/idempotency-correlation-rules.md
@@ -1,0 +1,40 @@
+# Idempotency and Correlation Rules (v1)
+
+## Purpose
+
+Define deterministic behavior for retries and multi-step workflow tracing.
+
+## Identifiers
+
+- `intent_id`
+  - Unique per intent message/event.
+  - Must be a UUID.
+- `correlation_id`
+  - Stable UUID shared across all messages/events in the same logical workflow.
+  - Must remain unchanged across retries and follow-up actions for the same workflow.
+- `idempotency_key` (optional in envelope, required for external retry-safe writes)
+  - Stable client-generated token for deduplicating create operations.
+
+## Idempotency Rules
+
+- Deduplication key for create operations:
+  - `(sender_identity, endpoint, idempotency_key)`
+- If the same dedup key is received again, service must return the original accepted result.
+- If payload differs under the same dedup key, service should reject with a conflict error.
+- Recommended key TTL for dedup cache/index in MVP:
+  - at least 24 hours.
+
+## Correlation Rules
+
+- New workflow:
+  - Generate a new `correlation_id`.
+- Existing workflow step/retry:
+  - Reuse the same `correlation_id`.
+- All status and error events must be attributable to the same `correlation_id`.
+
+## Error Handling Guidance
+
+- Validation/auth errors:
+  - usually non-retryable with same payload.
+- Transport/timeout errors:
+  - may be retryable with the same `idempotency_key` and `correlation_id`.

--- a/docs/protocol-error-status-model.md
+++ b/docs/protocol-error-status-model.md
@@ -1,0 +1,52 @@
+# Protocol Error and Status Model (v1)
+
+## Scope
+
+Defines canonical payload models for workflow status updates and machine-readable errors.
+
+## Schema Files
+
+- `schemas/protocol/intent.status.v1.json`
+- `schemas/protocol/intent.error.v1.json`
+
+## Status Model (`intent.status.v1`)
+
+Fields:
+
+- `workflow_status` (required):
+  - `planned`
+  - `validated`
+  - `running`
+  - `blocked`
+  - `done`
+  - `failed`
+- `updated_at` (required, RFC3339 timestamp)
+- `reason` (optional, human-readable context)
+- `actor` (optional, service or agent identity)
+
+Usage:
+
+- Emitted when workflow state changes.
+- `blocked` and `failed` should include `reason` whenever possible.
+
+## Error Model (`intent.error.v1`)
+
+Fields:
+
+- `code` (required, machine-readable stable code)
+- `message` (required, human-readable summary)
+- `category` (required):
+  - `validation`
+  - `auth`
+  - `policy`
+  - `transport`
+  - `timeout`
+  - `internal`
+- `retryable` (required boolean)
+- `at` (required, RFC3339 timestamp)
+- `details` (optional key-value map)
+
+Usage:
+
+- Used for predictable API and workflow error payloads.
+- `retryable=true` indicates caller may retry with same correlation context.

--- a/docs/public-api-schema-index.md
+++ b/docs/public-api-schema-index.md
@@ -1,0 +1,149 @@
+# Public API Schema Index (Step 4)
+
+## Scope
+
+Schemas for external client contracts in `services/gateway` API.
+
+Related artifacts:
+
+- OpenAPI export: `docs/openapi/gateway.v1.json`
+- Auth/idempotency/rate-limit docs: `docs/public-api-auth.md`
+
+## Files
+
+- `schemas/public_api/api.intents.create.request.v1.json`
+- `schemas/public_api/api.intents.create.response.v1.json`
+- `schemas/public_api/api.intents.get.response.v1.json`
+- `schemas/public_api/api.approvals.decision.request.v1.json`
+- `schemas/public_api/api.approvals.decision.response.v1.json`
+- `schemas/public_api/api.webhooks.events.request.v1.json`
+- `schemas/public_api/api.webhooks.events.response.v1.json`
+- `schemas/public_api/api.webhooks.events.replay.response.v1.json`
+- `schemas/public_api/api.webhooks.subscriptions.upsert.request.v1.json`
+- `schemas/public_api/api.webhooks.subscriptions.response.v1.json`
+- `schemas/public_api/api.webhooks.subscriptions.list.response.v1.json`
+- `schemas/public_api/api.webhooks.subscriptions.delete.response.v1.json`
+- `schemas/public_api/api.capabilities.get.response.v1.json`
+- `schemas/public_api/api.schemas.upsert.request.v1.json`
+- `schemas/public_api/api.schemas.upsert.response.v1.json`
+- `schemas/public_api/api.schemas.get.response.v1.json`
+- `schemas/public_api/api.inbox.list.response.v1.json`
+- `schemas/public_api/api.inbox.changes.response.v1.json`
+- `schemas/public_api/api.inbox.thread.response.v1.json`
+- `schemas/public_api/api.inbox.reply.request.v1.json`
+- `schemas/public_api/api.inbox.messages.delete.request.v1.json`
+- `schemas/public_api/api.inbox.messages.delete.response.v1.json`
+- `schemas/public_api/api.inbox.delegate.request.v1.json`
+- `schemas/public_api/api.inbox.decision.request.v1.json`
+- `schemas/public_api/api.users.register_nick.request.v1.json`
+- `schemas/public_api/api.users.register_nick.response.v1.json`
+- `schemas/public_api/api.users.check_nick.response.v1.json`
+- `schemas/public_api/api.users.rename_nick.request.v1.json`
+- `schemas/public_api/api.users.rename_nick.response.v1.json`
+- `schemas/public_api/api.users.profile.get.response.v1.json`
+- `schemas/public_api/api.users.profile.update.request.v1.json`
+- `schemas/public_api/api.users.profile.update.response.v1.json`
+- `schemas/public_api/api.invites.create.request.v1.json`
+- `schemas/public_api/api.invites.create.response.v1.json`
+- `schemas/public_api/api.invites.get.response.v1.json`
+- `schemas/public_api/api.invites.accept.request.v1.json`
+- `schemas/public_api/api.invites.accept.response.v1.json`
+- `schemas/public_api/api.media.create_upload.request.v1.json`
+- `schemas/public_api/api.media.create_upload.response.v1.json`
+- `schemas/public_api/api.media.finalize_upload.request.v1.json`
+- `schemas/public_api/api.media.finalize_upload.response.v1.json`
+- `schemas/public_api/api.media.get.response.v1.json`
+
+## Endpoint Mapping
+
+- `POST /v1/intents`
+  - request: `api.intents.create.request.v1.json`
+  - response: `api.intents.create.response.v1.json`
+- `GET /v1/intents/{intent_id}`
+  - response: `api.intents.get.response.v1.json`
+- `POST /v1/approvals/{approval_id}/decision`
+  - request: `api.approvals.decision.request.v1.json`
+  - response: `api.approvals.decision.response.v1.json`
+- `POST /v1/webhooks/events`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - request: `api.webhooks.events.request.v1.json`
+  - response: `api.webhooks.events.response.v1.json`
+- `POST /v1/webhooks/events/{event_id}/replay`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - response: `api.webhooks.events.replay.response.v1.json`
+- `POST /v1/webhooks/subscriptions`
+  - request: `api.webhooks.subscriptions.upsert.request.v1.json`
+  - response: `api.webhooks.subscriptions.response.v1.json`
+- `GET /v1/webhooks/subscriptions`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - response: `api.webhooks.subscriptions.list.response.v1.json`
+- `DELETE /v1/webhooks/subscriptions/{subscription_id}`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - response: `api.webhooks.subscriptions.delete.response.v1.json`
+- `GET /v1/capabilities`
+  - response: `api.capabilities.get.response.v1.json`
+- `POST /v1/schemas`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - request: `api.schemas.upsert.request.v1.json`
+  - response: `api.schemas.upsert.response.v1.json`
+- `GET /v1/schemas/{semantic_type}`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - response: `api.schemas.get.response.v1.json`
+- `GET /v1/inbox`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - response: `api.inbox.list.response.v1.json`
+- `GET /v1/inbox/changes`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - response: `api.inbox.changes.response.v1.json`
+- `GET /v1/inbox/{thread_id}`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - response: `api.inbox.thread.response.v1.json`
+- `POST /v1/inbox/{thread_id}/reply`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - request: `api.inbox.reply.request.v1.json`
+  - response: `api.inbox.thread.response.v1.json`
+- `POST /v1/inbox/{thread_id}/messages/delete`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - request: `api.inbox.messages.delete.request.v1.json`
+  - response: `api.inbox.messages.delete.response.v1.json`
+- `POST /v1/inbox/{thread_id}/delegate`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - request: `api.inbox.delegate.request.v1.json`
+  - response: `api.inbox.thread.response.v1.json`
+- `POST /v1/inbox/{thread_id}/approve`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - request: `api.inbox.decision.request.v1.json`
+  - response: `api.inbox.thread.response.v1.json`
+- `POST /v1/inbox/{thread_id}/reject`
+  - owner scoping: `x-owner-agent` header or `owner_agent` query
+  - request: `api.inbox.decision.request.v1.json`
+  - response: `api.inbox.thread.response.v1.json`
+- `POST /v1/users/register-nick`
+  - request: `api.users.register_nick.request.v1.json`
+  - response: `api.users.register_nick.response.v1.json`
+- `GET /v1/users/check-nick?nick=...`
+  - response: `api.users.check_nick.response.v1.json`
+- `POST /v1/users/rename-nick`
+  - request: `api.users.rename_nick.request.v1.json`
+  - response: `api.users.rename_nick.response.v1.json`
+- `GET /v1/users/profile?owner_agent=...`
+  - response: `api.users.profile.get.response.v1.json`
+- `POST /v1/users/profile/update`
+  - request: `api.users.profile.update.request.v1.json`
+  - response: `api.users.profile.update.response.v1.json`
+- `POST /v1/invites/create`
+  - request: `api.invites.create.request.v1.json`
+  - response: `api.invites.create.response.v1.json`
+- `GET /v1/invites/{token}`
+  - response: `api.invites.get.response.v1.json`
+- `POST /v1/invites/{token}/accept`
+  - request: `api.invites.accept.request.v1.json`
+  - response: `api.invites.accept.response.v1.json`
+- `POST /v1/media/create-upload`
+  - request: `api.media.create_upload.request.v1.json`
+  - response: `api.media.create_upload.response.v1.json`
+- `POST /v1/media/finalize-upload`
+  - request: `api.media.finalize_upload.request.v1.json`
+  - response: `api.media.finalize_upload.response.v1.json`
+- `GET /v1/media/{upload_id}`
+  - response: `api.media.get.response.v1.json`

--- a/docs/schema-versioning-rules.md
+++ b/docs/schema-versioning-rules.md
@@ -1,0 +1,57 @@
+# Schema Versioning Rules
+
+## Scope
+
+Rules apply to:
+
+- `schemas/protocol/`
+- `schemas/public_api/`
+
+## Naming
+
+- Protocol filename format: `intent.<name>.v<version>.json`
+- Public API filename format: `api.<domain>.<action>.<request|response>.v<version>.json`
+- Current stable major for MVP: `v1`
+
+## Compatibility
+
+- Backward-compatible additions (optional fields, relaxed constraints) may remain in the same major version.
+- Breaking changes (required fields, stricter constraints, enum removals/renames, semantic behavior changes) require a new major version file (`v2`, `v3`, ...).
+
+## Change Policy
+
+- Never overwrite the behavior of an existing released major version.
+- New major version is introduced as a new file.
+- Keep old major versions available while clients migrate.
+
+## Validation Gate
+
+- All schema files must pass `python scripts/validate_schemas.py`.
+- CI workflow `Schema Validation` must stay green before merge.
+- Contract tests for valid/invalid payload behavior must pass:
+  - `pytest -q tests/test_schema_contracts.py`
+  - `pytest -q tests/test_public_api_schema_contracts.py`
+
+## Required Protocol Schemas (v1 line)
+
+- `intent.envelope.v1.json`
+- `intent.ask.v1.json`
+- `intent.reply.v1.json`
+- `intent.status.v1.json`
+- `intent.error.v1.json`
+
+## Required Public API Schemas (v1 line)
+
+- `api.intents.create.request.v1.json`
+- `api.intents.create.response.v1.json`
+- `api.intents.get.response.v1.json`
+- `api.approvals.decision.request.v1.json`
+- `api.approvals.decision.response.v1.json`
+- `api.webhooks.events.request.v1.json`
+- `api.webhooks.events.response.v1.json`
+- `api.capabilities.get.response.v1.json`
+- `api.inbox.list.response.v1.json`
+- `api.inbox.thread.response.v1.json`
+- `api.inbox.reply.request.v1.json`
+- `api.inbox.delegate.request.v1.json`
+- `api.inbox.decision.request.v1.json`

--- a/schemas/protocol/intent.ask.v1.json
+++ b/schemas/protocol/intent.ask.v1.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/protocol/intent.ask.v1.json",
+  "title": "IntentAskV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "question",
+    "requested_by",
+    "requested_at"
+  ],
+  "properties": {
+    "question": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2000
+    },
+    "context": {
+      "type": "string",
+      "maxLength": 5000
+    },
+    "deadline_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "requested_by": {
+      "type": "string",
+      "minLength": 3
+    },
+    "requested_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "workflow": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/protocol/intent.envelope.v1.json
+++ b/schemas/protocol/intent.envelope.v1.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/protocol/intent.envelope.v1.json",
+  "title": "IntentEnvelopeV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "intent_type",
+    "intent_id",
+    "correlation_id",
+    "created_at",
+    "from_agent",
+    "to_agent",
+    "payload"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "v1"
+    },
+    "intent_type": {
+      "type": "string",
+      "pattern": "^intent\\.[a-z0-9_]+\\.v1$"
+    },
+    "intent_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "correlation_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "idempotency_key": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 128
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "from_agent": {
+      "type": "string",
+      "minLength": 3
+    },
+    "to_agent": {
+      "type": "string",
+      "minLength": 3
+    },
+    "payload": {
+      "type": "object"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/protocol/intent.error.v1.json
+++ b/schemas/protocol/intent.error.v1.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/protocol/intent.error.v1.json",
+  "title": "IntentErrorV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "code",
+    "message",
+    "category",
+    "retryable",
+    "at"
+  ],
+  "properties": {
+    "code": {
+      "type": "string",
+      "pattern": "^[a-z0-9_:.\\-]{3,128}$"
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2000
+    },
+    "category": {
+      "type": "string",
+      "enum": [
+        "validation",
+        "auth",
+        "policy",
+        "transport",
+        "timeout",
+        "internal"
+      ]
+    },
+    "retryable": {
+      "type": "boolean"
+    },
+    "at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/protocol/intent.reply.v1.json
+++ b/schemas/protocol/intent.reply.v1.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/protocol/intent.reply.v1.json",
+  "title": "IntentReplyV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "answer",
+    "status",
+    "responded_by",
+    "responded_at"
+  ],
+  "properties": {
+    "answer": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 5000
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "answered",
+        "needs_clarification",
+        "declined",
+        "timeout"
+      ]
+    },
+    "clarification_question": {
+      "type": "string",
+      "maxLength": 2000
+    },
+    "responded_by": {
+      "type": "string",
+      "minLength": 3
+    },
+    "responded_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "workflow": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "needs_clarification"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "clarification_question"
+        ]
+      }
+    }
+  ]
+}

--- a/schemas/protocol/intent.status.v1.json
+++ b/schemas/protocol/intent.status.v1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/protocol/intent.status.v1.json",
+  "title": "IntentStatusV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "workflow_status",
+    "updated_at"
+  ],
+  "properties": {
+    "workflow_status": {
+      "type": "string",
+      "enum": [
+        "planned",
+        "validated",
+        "running",
+        "blocked",
+        "done",
+        "failed"
+      ]
+    },
+    "reason": {
+      "type": "string",
+      "maxLength": 2000
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "actor": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    }
+  }
+}

--- a/schemas/protocol/message.envelope.v3.json
+++ b/schemas/protocol/message.envelope.v3.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/protocol/message.envelope.v3.json",
+  "title": "MessageEnvelopeV3Encrypted",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "message_id",
+    "from",
+    "to",
+    "content_kind",
+    "ciphertext",
+    "encryption",
+    "trace"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "v3"
+    },
+    "message_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "thread_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uuid"
+    },
+    "from": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "to": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": {
+        "type": "string",
+        "minLength": 3,
+        "maxLength": 255
+      }
+    },
+    "content_kind": {
+      "type": "string",
+      "enum": [
+        "text",
+        "intent",
+        "media",
+        "system"
+      ]
+    },
+    "ciphertext": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "type",
+        "body"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "m.room.encrypted"
+          ]
+        },
+        "body": {
+          "type": "object"
+        }
+      }
+    },
+    "encryption": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "algorithm"
+      ],
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "enum": [
+            "m.megolm.v1.aes-sha2",
+            "m.olm.v1.curve25519-aes-sha2"
+          ]
+        },
+        "sender_key": {
+          "type": "string",
+          "minLength": 8,
+          "maxLength": 512
+        },
+        "session_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "device_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      }
+    },
+    "attachments": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "upload_id"
+        ],
+        "properties": {
+          "upload_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "mime_type": {
+            "type": "string",
+            "minLength": 3
+          }
+        }
+      }
+    },
+    "transport": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "matrix_room_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "matrix_event_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "correlation_id"
+      ],
+      "properties": {
+        "correlation_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "causation_id": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "string",
+          "number",
+          "boolean",
+          "null"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add remaining protocol schemas (`intent.* v1` and `message.envelope.v3`)
- add schema governance docs from split map (`schema versioning`, `idempotency/correlation`, `error/status`, schema index)
- update README to reflect wave-2 extraction scope

## Test plan
- [x] `/.venv/bin/python -m pip install -e \".[dev]\"`
- [x] `/.venv/bin/python scripts/validate_schemas.py`
- [x] `/.venv/bin/python -m pytest -q`
- [x] Result: `schema validation passed`, `1 passed`

Made with [Cursor](https://cursor.com)