### PR TITLE
feat: extract core public API schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ AXP protocol specifications, schemas, and compatibility notes.
 
 ## Status
 
-Wave 2 extraction in progress.
+Wave 3 extraction in progress.
 
-## Included through Wave 2
+## Included through Wave 3
 
 - Protocol schemas:
   - `schemas/protocol/intent.ask.v1.json`
@@ -22,6 +22,13 @@ Wave 2 extraction in progress.
   - `docs/schema-versioning-rules.md`
   - `docs/protocol-error-status-model.md`
   - `docs/idempotency-correlation-rules.md`
+- Public API schemas (core set):
+  - `schemas/public_api/api.intents.create.request.v1.json`
+  - `schemas/public_api/api.intents.create.response.v1.json`
+  - `schemas/public_api/api.intents.get.response.v1.json`
+  - `schemas/public_api/api.approvals.decision.request.v1.json`
+  - `schemas/public_api/api.approvals.decision.response.v1.json`
+  - `schemas/public_api/api.capabilities.get.response.v1.json`
 - Schema validation script, tests, and CI gate
 
 ## Development

--- a/schemas/public_api/api.approvals.decision.request.v1.json
+++ b/schemas/public_api/api.approvals.decision.request.v1.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.approvals.decision.request.v1.json",
+  "title": "ApiApprovalsDecisionRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "decision"
+  ],
+  "properties": {
+    "decision": {
+      "type": "string",
+      "enum": [
+        "approve",
+        "reject"
+      ]
+    },
+    "comment": {
+      "type": "string",
+      "maxLength": 1000
+    }
+  }
+}

--- a/schemas/public_api/api.approvals.decision.response.v1.json
+++ b/schemas/public_api/api.approvals.decision.response.v1.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.approvals.decision.response.v1.json",
+  "title": "ApiApprovalsDecisionResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "approval"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "approval_id",
+        "decision",
+        "decided_at"
+      ],
+      "properties": {
+        "approval_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "decision": {
+          "type": "string",
+          "enum": [
+            "approve",
+            "reject"
+          ]
+        },
+        "comment": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 1000
+        },
+        "decided_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.capabilities.get.response.v1.json
+++ b/schemas/public_api/api.capabilities.get.response.v1.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.capabilities.get.response.v1.json",
+  "title": "ApiCapabilitiesGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "capabilities",
+    "supported_intent_types"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 3,
+        "maxLength": 120
+      },
+      "minItems": 1
+    },
+    "supported_intent_types": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^intent\\.[a-z0-9_]+\\.v1$"
+      },
+      "minItems": 1
+    }
+  }
+}

--- a/schemas/public_api/api.intents.create.request.v1.json
+++ b/schemas/public_api/api.intents.create.request.v1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.intents.create.request.v1.json",
+  "title": "ApiIntentsCreateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "intent_type",
+    "correlation_id",
+    "from_agent",
+    "to_agent",
+    "payload"
+  ],
+  "properties": {
+    "intent_type": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+(?:\\.[a-z0-9_]+)+\\.v[0-9]+$"
+    },
+    "correlation_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "from_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "to_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/public_api/api.intents.create.response.v1.json
+++ b/schemas/public_api/api.intents.create.response.v1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.intents.create.response.v1.json",
+  "title": "ApiIntentsCreateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "intent_id",
+    "status",
+    "created_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "intent_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "running",
+        "blocked",
+        "done",
+        "failed"
+      ]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/public_api/api.intents.get.response.v1.json
+++ b/schemas/public_api/api.intents.get.response.v1.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.intents.get.response.v1.json",
+  "title": "ApiIntentsGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "intent"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "intent": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "intent_id",
+        "status",
+        "created_at",
+        "intent_type",
+        "correlation_id",
+        "from_agent",
+        "to_agent",
+        "payload"
+      ],
+      "properties": {
+        "intent_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "status": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "intent_type": {
+          "type": "string"
+        },
+        "correlation_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "from_agent": {
+          "type": "string"
+        },
+        "to_agent": {
+          "type": "string"
+        },
+        "payload": {
+          "type": "object"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add first public API schema set to `axme-spec` (`intents`, `approvals`, `capabilities`)
- update README with wave-3 extraction scope
- keep schema validation/test gates green for extracted artifacts

## Test plan
- [x] `/.venv/bin/python -m pip install -e \".[dev]\"`
- [x] `/.venv/bin/python scripts/validate_schemas.py`
- [x] `/.venv/bin/python -m pytest -q`
- [x] Result: `schema validation passed`, `1 passed`

Made with [Cursor](https://cursor.com)