### PR TITLE
feat: extract inbox public API schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ AXP protocol specifications, schemas, and compatibility notes.
 
 ## Status
 
-Wave 3 extraction in progress.
+Wave 4 extraction in progress.
 
-## Included through Wave 3
+## Included through Wave 4
 
 - Protocol schemas:
   - `schemas/protocol/intent.ask.v1.json`
@@ -29,6 +29,15 @@ Wave 3 extraction in progress.
   - `schemas/public_api/api.approvals.decision.request.v1.json`
   - `schemas/public_api/api.approvals.decision.response.v1.json`
   - `schemas/public_api/api.capabilities.get.response.v1.json`
+- Public API schemas (inbox set):
+  - `schemas/public_api/api.inbox.list.response.v1.json`
+  - `schemas/public_api/api.inbox.changes.response.v1.json`
+  - `schemas/public_api/api.inbox.thread.response.v1.json`
+  - `schemas/public_api/api.inbox.reply.request.v1.json`
+  - `schemas/public_api/api.inbox.messages.delete.request.v1.json`
+  - `schemas/public_api/api.inbox.messages.delete.response.v1.json`
+  - `schemas/public_api/api.inbox.delegate.request.v1.json`
+  - `schemas/public_api/api.inbox.decision.request.v1.json`
 - Schema validation script, tests, and CI gate
 
 ## Development

--- a/schemas/public_api/api.inbox.changes.response.v1.json
+++ b/schemas/public_api/api.inbox.changes.response.v1.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.inbox.changes.response.v1.json",
+  "title": "ApiInboxChangesResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "changes",
+    "next_cursor",
+    "has_more"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "changes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "cursor",
+          "thread"
+        ],
+        "properties": {
+          "cursor": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 128
+          },
+          "thread": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "thread_id",
+              "intent_id",
+              "status",
+              "owner_agent",
+              "from_agent",
+              "to_agent",
+              "created_at",
+              "updated_at",
+              "timeline"
+            ],
+            "properties": {
+              "thread_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "intent_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "active",
+                  "done"
+                ]
+              },
+              "owner_agent": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 255
+              },
+              "from_agent": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 255
+              },
+              "to_agent": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 255
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "timeline": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "required": [
+                    "event_id",
+                    "event_type",
+                    "actor",
+                    "at",
+                    "details"
+                  ],
+                  "properties": {
+                    "event_id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "event_type": {
+                      "type": "string",
+                      "minLength": 3,
+                      "maxLength": 120
+                    },
+                    "actor": {
+                      "type": "string",
+                      "minLength": 2,
+                      "maxLength": 120
+                    },
+                    "at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "details": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "next_cursor": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "has_more": {
+      "type": "boolean"
+    }
+  }
+}

--- a/schemas/public_api/api.inbox.decision.request.v1.json
+++ b/schemas/public_api/api.inbox.decision.request.v1.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.inbox.decision.request.v1.json",
+  "title": "ApiInboxDecisionRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "comment": {
+      "type": "string",
+      "maxLength": 2000
+    }
+  }
+}

--- a/schemas/public_api/api.inbox.delegate.request.v1.json
+++ b/schemas/public_api/api.inbox.delegate.request.v1.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.inbox.delegate.request.v1.json",
+  "title": "ApiInboxDelegateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "delegate_to": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "note": {
+      "type": "string",
+      "maxLength": 2000
+    }
+  }
+}

--- a/schemas/public_api/api.inbox.list.response.v1.json
+++ b/schemas/public_api/api.inbox.list.response.v1.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.inbox.list.response.v1.json",
+  "title": "ApiInboxListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "threads"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "threads": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "thread_id",
+          "intent_id",
+          "status",
+          "owner_agent",
+          "from_agent",
+          "to_agent",
+          "created_at",
+          "updated_at",
+          "timeline"
+        ],
+        "properties": {
+          "thread_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "intent_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "active",
+              "done"
+            ]
+          },
+          "owner_agent": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 255
+          },
+          "from_agent": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 255
+          },
+          "to_agent": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 255
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "timeline": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": [
+                "event_id",
+                "event_type",
+                "actor",
+                "at",
+                "details"
+              ],
+              "properties": {
+                "event_id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "event_type": {
+                  "type": "string",
+                  "minLength": 3,
+                  "maxLength": 120
+                },
+                "actor": {
+                  "type": "string",
+                  "minLength": 2,
+                  "maxLength": 120
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "details": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.inbox.messages.delete.request.v1.json
+++ b/schemas/public_api/api.inbox.messages.delete.request.v1.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.inbox.messages.delete.request.v1.json",
+  "title": "ApiInboxMessagesDeleteRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "mode"
+  ],
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": [
+        "self",
+        "both"
+      ]
+    },
+    "message_ids": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 100,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100
+    }
+  }
+}

--- a/schemas/public_api/api.inbox.messages.delete.response.v1.json
+++ b/schemas/public_api/api.inbox.messages.delete.response.v1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.inbox.messages.delete.response.v1.json",
+  "title": "ApiInboxMessagesDeleteResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "thread",
+    "mode",
+    "deleted_count",
+    "message_ids"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "thread": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "self",
+        "both"
+      ]
+    },
+    "deleted_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "message_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.inbox.reply.request.v1.json
+++ b/schemas/public_api/api.inbox.reply.request.v1.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.inbox.reply.request.v1.json",
+  "title": "ApiInboxReplyRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "message"
+  ],
+  "properties": {
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 5000
+    }
+  }
+}

--- a/schemas/public_api/api.inbox.thread.response.v1.json
+++ b/schemas/public_api/api.inbox.thread.response.v1.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.inbox.thread.response.v1.json",
+  "title": "ApiInboxThreadResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "thread"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "thread": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "thread_id",
+        "intent_id",
+        "status",
+        "owner_agent",
+        "from_agent",
+        "to_agent",
+        "created_at",
+        "updated_at",
+        "timeline"
+      ],
+      "properties": {
+        "thread_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "intent_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "active",
+            "done"
+          ]
+        },
+        "owner_agent": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "from_agent": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "to_agent": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "timeline": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "event_id",
+              "event_type",
+              "actor",
+              "at",
+              "details"
+            ],
+            "properties": {
+              "event_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "event_type": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 120
+              },
+              "actor": {
+                "type": "string",
+                "minLength": 2,
+                "maxLength": 120
+              },
+              "at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "details": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Wave 4: extract inbox public API schemas and keep schema validation/test gates green.

Made with [Cursor](https://cursor.com)