### PR TITLE
feat: extract webhooks public API schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ AXP protocol specifications, schemas, and compatibility notes.
 
 ## Status
 
-Wave 4 extraction in progress.
+Track B extraction in progress.
 
-## Included through Wave 4
+## Included in current extraction scope
 
 - Protocol schemas:
   - `schemas/protocol/intent.ask.v1.json`
@@ -38,6 +38,14 @@ Wave 4 extraction in progress.
   - `schemas/public_api/api.inbox.messages.delete.response.v1.json`
   - `schemas/public_api/api.inbox.delegate.request.v1.json`
   - `schemas/public_api/api.inbox.decision.request.v1.json`
+- Public API schemas (webhooks set):
+  - `schemas/public_api/api.webhooks.events.request.v1.json`
+  - `schemas/public_api/api.webhooks.events.response.v1.json`
+  - `schemas/public_api/api.webhooks.events.replay.response.v1.json`
+  - `schemas/public_api/api.webhooks.subscriptions.upsert.request.v1.json`
+  - `schemas/public_api/api.webhooks.subscriptions.response.v1.json`
+  - `schemas/public_api/api.webhooks.subscriptions.list.response.v1.json`
+  - `schemas/public_api/api.webhooks.subscriptions.delete.response.v1.json`
 - Schema validation script, tests, and CI gate
 
 ## Development

--- a/schemas/public_api/api.webhooks.events.replay.response.v1.json
+++ b/schemas/public_api/api.webhooks.events.replay.response.v1.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.webhooks.events.replay.response.v1.json",
+  "title": "ApiWebhooksEventsReplayResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "event_id",
+    "owner_agent",
+    "event_type",
+    "queued_deliveries",
+    "processed_deliveries",
+    "delivered",
+    "pending",
+    "dead_lettered",
+    "replayed_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "event_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "inbox.thread_created",
+        "inbox.thread_updated",
+        "inbox.reply_received",
+        "invite.accepted",
+        "auth.session_revoked"
+      ]
+    },
+    "queued_deliveries": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "processed_deliveries": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "delivered": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "pending": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "dead_lettered": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "replayed_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/public_api/api.webhooks.events.request.v1.json
+++ b/schemas/public_api/api.webhooks.events.request.v1.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.webhooks.events.request.v1.json",
+  "title": "ApiWebhooksEventsRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_type",
+    "source",
+    "payload"
+  ],
+  "properties": {
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "inbox.thread_created",
+        "inbox.thread_updated",
+        "inbox.reply_received",
+        "invite.accepted",
+        "auth.session_revoked"
+      ]
+    },
+    "source": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 100
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/public_api/api.webhooks.events.response.v1.json
+++ b/schemas/public_api/api.webhooks.events.response.v1.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.webhooks.events.response.v1.json",
+  "title": "ApiWebhooksEventsResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "accepted_at",
+    "event_type",
+    "source",
+    "owner_agent",
+    "event_id",
+    "queued_deliveries",
+    "processed_deliveries",
+    "delivered",
+    "pending",
+    "dead_lettered"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "accepted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "event_type": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 100
+    },
+    "source": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 100
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "event_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "queued_deliveries": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "processed_deliveries": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "delivered": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "pending": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "dead_lettered": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/schemas/public_api/api.webhooks.subscriptions.delete.response.v1.json
+++ b/schemas/public_api/api.webhooks.subscriptions.delete.response.v1.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.webhooks.subscriptions.delete.response.v1.json",
+  "title": "ApiWebhooksSubscriptionsDeleteResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "subscription_id",
+    "revoked_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "subscription_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "revoked_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/public_api/api.webhooks.subscriptions.list.response.v1.json
+++ b/schemas/public_api/api.webhooks.subscriptions.list.response.v1.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.webhooks.subscriptions.list.response.v1.json",
+  "title": "ApiWebhooksSubscriptionsListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "subscriptions"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "subscriptions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "subscription_id",
+          "owner_agent",
+          "callback_url",
+          "event_types",
+          "active",
+          "created_at",
+          "updated_at",
+          "revoked_at",
+          "secret_hint"
+        ],
+        "properties": {
+          "subscription_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "owner_agent": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 255
+          },
+          "callback_url": {
+            "type": "string",
+            "format": "uri",
+            "minLength": 8,
+            "maxLength": 2048
+          },
+          "event_types": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 255
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "revoked_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "secret_hint": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.webhooks.subscriptions.response.v1.json
+++ b/schemas/public_api/api.webhooks.subscriptions.response.v1.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.webhooks.subscriptions.response.v1.json",
+  "title": "ApiWebhooksSubscriptionsResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "subscription"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "subscription": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "subscription_id",
+        "owner_agent",
+        "callback_url",
+        "event_types",
+        "active",
+        "created_at",
+        "updated_at",
+        "revoked_at",
+        "secret_hint"
+      ],
+      "properties": {
+        "subscription_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "owner_agent": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "callback_url": {
+          "type": "string",
+          "format": "uri",
+          "minLength": 8,
+          "maxLength": 2048
+        },
+        "event_types": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 255
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revoked_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "secret_hint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.webhooks.subscriptions.upsert.request.v1.json
+++ b/schemas/public_api/api.webhooks.subscriptions.upsert.request.v1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.webhooks.subscriptions.upsert.request.v1.json",
+  "title": "ApiWebhooksSubscriptionsUpsertRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "callback_url",
+    "event_types"
+  ],
+  "properties": {
+    "callback_url": {
+      "type": "string",
+      "format": "uri",
+      "minLength": 8,
+      "maxLength": 2048
+    },
+    "event_types": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": {
+        "type": "string",
+        "enum": [
+          "inbox.thread_created",
+          "inbox.thread_updated",
+          "inbox.reply_received",
+          "invite.accepted",
+          "auth.session_revoked"
+        ]
+      }
+    },
+    "secret": {
+      "type": "string",
+      "minLength": 16,
+      "maxLength": 128
+    },
+    "active": {
+      "type": "boolean"
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 255
+    }
+  }
+}


### PR DESCRIPTION
## Track
- Track B (Public Spec and Documentation)

## Scope
- migrate webhooks schema contracts to `axme-spec`:
  - `api.webhooks.events.request.v1.json`
  - `api.webhooks.events.response.v1.json`
  - `api.webhooks.events.replay.response.v1.json`
  - `api.webhooks.subscriptions.upsert.request.v1.json`
  - `api.webhooks.subscriptions.response.v1.json`
  - `api.webhooks.subscriptions.list.response.v1.json`
  - `api.webhooks.subscriptions.delete.response.v1.json`

## Test plan
- [x] `/.venv/bin/python -m pip install -e \".[dev]\"`
- [x] `/.venv/bin/python scripts/validate_schemas.py`
- [x] `/.venv/bin/python -m pytest -q`
- [x] Result: `schema validation passed`, `1 passed`

Made with [Cursor](https://cursor.com)