### PR TITLE
feat: extract users public API schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ Track B extraction in progress.
   - `schemas/public_api/api.webhooks.subscriptions.response.v1.json`
   - `schemas/public_api/api.webhooks.subscriptions.list.response.v1.json`
   - `schemas/public_api/api.webhooks.subscriptions.delete.response.v1.json`
+- Public API schemas (users/profile set):
+  - `schemas/public_api/api.users.register_nick.request.v1.json`
+  - `schemas/public_api/api.users.register_nick.response.v1.json`
+  - `schemas/public_api/api.users.check_nick.response.v1.json`
+  - `schemas/public_api/api.users.rename_nick.request.v1.json`
+  - `schemas/public_api/api.users.rename_nick.response.v1.json`
+  - `schemas/public_api/api.users.profile.get.response.v1.json`
+  - `schemas/public_api/api.users.profile.update.request.v1.json`
+  - `schemas/public_api/api.users.profile.update.response.v1.json`
 - Schema validation script, tests, and CI gate
 
 ## Development

--- a/schemas/public_api/api.users.check_nick.response.v1.json
+++ b/schemas/public_api/api.users.check_nick.response.v1.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.users.check_nick.response.v1.json",
+  "title": "ApiUsersCheckNickResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "nick",
+    "normalized_nick",
+    "public_address",
+    "available"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "nick": {
+      "type": "string",
+      "pattern": "^@[\\w.-]{3,32}$"
+    },
+    "normalized_nick": {
+      "type": "string",
+      "pattern": "^[\\w.-]{3,32}$"
+    },
+    "public_address": {
+      "type": "string",
+      "pattern": "^[\\w.-]{3,32}@ax$"
+    },
+    "available": {
+      "type": "boolean"
+    }
+  }
+}

--- a/schemas/public_api/api.users.profile.get.response.v1.json
+++ b/schemas/public_api/api.users.profile.get.response.v1.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.users.profile.get.response.v1.json",
+  "title": "ApiUsersProfileGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "user_id",
+    "owner_agent",
+    "nick",
+    "normalized_nick",
+    "public_address",
+    "updated_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "user_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "nick": {
+      "type": "string",
+      "pattern": "^@[\\w.-]{3,32}$"
+    },
+    "normalized_nick": {
+      "type": "string",
+      "pattern": "^[\\w.-]{3,32}$"
+    },
+    "public_address": {
+      "type": "string",
+      "pattern": "^[\\w.-]{3,32}@ax$"
+    },
+    "display_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "phone": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 3,
+      "maxLength": 32
+    },
+    "email": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/public_api/api.users.profile.update.request.v1.json
+++ b/schemas/public_api/api.users.profile.update.request.v1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.users.profile.update.request.v1.json",
+  "title": "ApiUsersProfileUpdateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "owner_agent"
+  ],
+  "properties": {
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "nick": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "phone": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 32
+    },
+    "email": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    }
+  }
+}

--- a/schemas/public_api/api.users.profile.update.response.v1.json
+++ b/schemas/public_api/api.users.profile.update.response.v1.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.users.profile.update.response.v1.json",
+  "title": "ApiUsersProfileUpdateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "user_id",
+    "owner_agent",
+    "nick",
+    "normalized_nick",
+    "public_address",
+    "updated_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "user_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "nick": {
+      "type": "string",
+      "pattern": "^@[\\w.-]{3,32}$"
+    },
+    "normalized_nick": {
+      "type": "string",
+      "pattern": "^[\\w.-]{3,32}$"
+    },
+    "public_address": {
+      "type": "string",
+      "pattern": "^[\\w.-]{3,32}@ax$"
+    },
+    "display_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "phone": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 3,
+      "maxLength": 32
+    },
+    "email": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/public_api/api.users.register_nick.request.v1.json
+++ b/schemas/public_api/api.users.register_nick.request.v1.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.users.register_nick.request.v1.json",
+  "title": "ApiUsersRegisterNickRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "nick"
+  ],
+  "properties": {
+    "nick": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "phone": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 32
+    },
+    "email": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    }
+  }
+}

--- a/schemas/public_api/api.users.register_nick.response.v1.json
+++ b/schemas/public_api/api.users.register_nick.response.v1.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.users.register_nick.response.v1.json",
+  "title": "ApiUsersRegisterNickResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "user_id",
+    "owner_agent",
+    "nick",
+    "public_address",
+    "created_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "user_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "nick": {
+      "type": "string",
+      "pattern": "^@[\\w.-]{3,32}$"
+    },
+    "public_address": {
+      "type": "string",
+      "pattern": "^[\\w.-]{3,32}@ax$"
+    },
+    "display_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "phone": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 3,
+      "maxLength": 32
+    },
+    "email": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/public_api/api.users.rename_nick.request.v1.json
+++ b/schemas/public_api/api.users.rename_nick.request.v1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.users.rename_nick.request.v1.json",
+  "title": "ApiUsersRenameNickRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "owner_agent",
+    "nick"
+  ],
+  "properties": {
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "nick": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "phone": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 32
+    },
+    "email": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    }
+  }
+}

--- a/schemas/public_api/api.users.rename_nick.response.v1.json
+++ b/schemas/public_api/api.users.rename_nick.response.v1.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.users.rename_nick.response.v1.json",
+  "title": "ApiUsersRenameNickResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "user_id",
+    "owner_agent",
+    "nick",
+    "public_address",
+    "renamed_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "user_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "nick": {
+      "type": "string",
+      "pattern": "^@[\\w.-]{3,32}$"
+    },
+    "public_address": {
+      "type": "string",
+      "pattern": "^[\\w.-]{3,32}@ax$"
+    },
+    "display_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "phone": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 3,
+      "maxLength": 32
+    },
+    "email": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "renamed_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}


### PR DESCRIPTION
## Track
- Track B (Public Spec and Documentation)

## Scope
- migrate users/profile schema contracts to `axme-spec`:
  - `api.users.register_nick.request.v1.json`
  - `api.users.register_nick.response.v1.json`
  - `api.users.check_nick.response.v1.json`
  - `api.users.rename_nick.request.v1.json`
  - `api.users.rename_nick.response.v1.json`
  - `api.users.profile.get.response.v1.json`
  - `api.users.profile.update.request.v1.json`
  - `api.users.profile.update.response.v1.json`

## Test plan
- [x] `/.venv/bin/python -m pip install -e \".[dev]\"`
- [x] `/.venv/bin/python scripts/validate_schemas.py`
- [x] `/.venv/bin/python -m pytest -q`
- [x] Result: `schema validation passed`, `1 passed`

Made with [Cursor](https://cursor.com)