### PR TITLE
feat: extract invites/media/schemas public API schema set

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ Track B extraction in progress.
   - `schemas/public_api/api.users.profile.get.response.v1.json`
   - `schemas/public_api/api.users.profile.update.request.v1.json`
   - `schemas/public_api/api.users.profile.update.response.v1.json`
+- Public API schemas (invites set):
+  - `schemas/public_api/api.invites.create.request.v1.json`
+  - `schemas/public_api/api.invites.create.response.v1.json`
+  - `schemas/public_api/api.invites.get.response.v1.json`
+  - `schemas/public_api/api.invites.accept.request.v1.json`
+  - `schemas/public_api/api.invites.accept.response.v1.json`
+- Public API schemas (media set):
+  - `schemas/public_api/api.media.create_upload.request.v1.json`
+  - `schemas/public_api/api.media.create_upload.response.v1.json`
+  - `schemas/public_api/api.media.finalize_upload.request.v1.json`
+  - `schemas/public_api/api.media.finalize_upload.response.v1.json`
+  - `schemas/public_api/api.media.get.response.v1.json`
+- Public API schemas (schemas set):
+  - `schemas/public_api/api.schemas.upsert.request.v1.json`
+  - `schemas/public_api/api.schemas.upsert.response.v1.json`
+  - `schemas/public_api/api.schemas.get.response.v1.json`
 - Schema validation script, tests, and CI gate
 
 ## Development

--- a/schemas/public_api/api.invites.accept.request.v1.json
+++ b/schemas/public_api/api.invites.accept.request.v1.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.invites.accept.request.v1.json",
+  "title": "ApiInvitesAcceptRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "nick"
+  ],
+  "properties": {
+    "nick": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120
+    }
+  }
+}

--- a/schemas/public_api/api.invites.accept.response.v1.json
+++ b/schemas/public_api/api.invites.accept.response.v1.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.invites.accept.response.v1.json",
+  "title": "ApiInvitesAcceptResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "token",
+    "status",
+    "invite_owner_agent",
+    "user_id",
+    "owner_agent",
+    "nick",
+    "public_address",
+    "accepted_at",
+    "registry_bind_status"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "token": {
+      "type": "string",
+      "minLength": 12,
+      "maxLength": 64
+    },
+    "status": {
+      "type": "string",
+      "const": "accepted"
+    },
+    "invite_owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "user_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "nick": {
+      "type": "string",
+      "pattern": "^@[\\w.-]{3,32}$"
+    },
+    "public_address": {
+      "type": "string",
+      "pattern": "^[\\w.-]{3,32}@[a-z0-9-]{2,32}$"
+    },
+    "display_name": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "accepted_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "registry_bind_status": {
+      "type": "string",
+      "enum": [
+        "propagated",
+        "failed",
+        "disabled",
+        "skipped_no_hint"
+      ]
+    }
+  }
+}

--- a/schemas/public_api/api.invites.create.request.v1.json
+++ b/schemas/public_api/api.invites.create.request.v1.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.invites.create.request.v1.json",
+  "title": "ApiInvitesCreateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "owner_agent"
+  ],
+  "properties": {
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "recipient_hint": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "ttl_seconds": {
+      "type": "integer",
+      "minimum": 60,
+      "maximum": 1209600
+    }
+  }
+}

--- a/schemas/public_api/api.invites.create.response.v1.json
+++ b/schemas/public_api/api.invites.create.response.v1.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.invites.create.response.v1.json",
+  "title": "ApiInvitesCreateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "token",
+    "invite_url",
+    "owner_agent",
+    "status",
+    "created_at",
+    "expires_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "token": {
+      "type": "string",
+      "minLength": 12,
+      "maxLength": 64
+    },
+    "invite_url": {
+      "type": "string",
+      "format": "uri"
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "recipient_hint": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "accepted",
+        "expired"
+      ]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/public_api/api.invites.get.response.v1.json
+++ b/schemas/public_api/api.invites.get.response.v1.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.invites.get.response.v1.json",
+  "title": "ApiInvitesGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "token",
+    "owner_agent",
+    "status",
+    "created_at",
+    "expires_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "token": {
+      "type": "string",
+      "minLength": 12,
+      "maxLength": 64
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "recipient_hint": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "accepted",
+        "expired"
+      ]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "accepted_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "accepted_owner_agent": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "nick": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^@[\\w.-]{3,32}$"
+    },
+    "public_address": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[\\w.-]{3,32}@[a-z0-9-]{2,32}$"
+    }
+  }
+}

--- a/schemas/public_api/api.media.create_upload.request.v1.json
+++ b/schemas/public_api/api.media.create_upload.request.v1.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.media.create_upload.request.v1.json",
+  "title": "ApiMediaCreateUploadRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "owner_agent",
+    "filename",
+    "mime_type",
+    "size_bytes"
+  ],
+  "properties": {
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "filename": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "mime_type": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "size_bytes": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 2147483648
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "ttl_seconds": {
+      "type": "integer",
+      "minimum": 60,
+      "maximum": 604800
+    }
+  }
+}

--- a/schemas/public_api/api.media.create_upload.response.v1.json
+++ b/schemas/public_api/api.media.create_upload.response.v1.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.media.create_upload.response.v1.json",
+  "title": "ApiMediaCreateUploadResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "upload_id",
+    "owner_agent",
+    "bucket",
+    "object_path",
+    "upload_url",
+    "status",
+    "expires_at",
+    "max_size_bytes"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "upload_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "bucket": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "object_path": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 1024
+    },
+    "upload_url": {
+      "type": "string",
+      "format": "uri"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "pending"
+      ]
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "max_size_bytes": {
+      "type": "integer",
+      "minimum": 1
+    }
+  }
+}

--- a/schemas/public_api/api.media.finalize_upload.request.v1.json
+++ b/schemas/public_api/api.media.finalize_upload.request.v1.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.media.finalize_upload.request.v1.json",
+  "title": "ApiMediaFinalizeUploadRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "upload_id",
+    "size_bytes"
+  ],
+  "properties": {
+    "upload_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "size_bytes": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 2147483648
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/schemas/public_api/api.media.finalize_upload.response.v1.json
+++ b/schemas/public_api/api.media.finalize_upload.response.v1.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.media.finalize_upload.response.v1.json",
+  "title": "ApiMediaFinalizeUploadResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "upload_id",
+    "owner_agent",
+    "bucket",
+    "object_path",
+    "mime_type",
+    "size_bytes",
+    "status",
+    "finalized_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "upload_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "owner_agent": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "bucket": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "object_path": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 1024
+    },
+    "mime_type": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "size_bytes": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 2147483648
+    },
+    "sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "ready"
+      ]
+    },
+    "finalized_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/public_api/api.media.get.response.v1.json
+++ b/schemas/public_api/api.media.get.response.v1.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.media.get.response.v1.json",
+  "title": "ApiMediaGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "upload"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "upload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "upload_id",
+        "owner_agent",
+        "bucket",
+        "object_path",
+        "mime_type",
+        "filename",
+        "size_bytes",
+        "sha256",
+        "status",
+        "created_at",
+        "expires_at",
+        "finalized_at",
+        "download_url",
+        "preview_url"
+      ],
+      "properties": {
+        "upload_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "owner_agent": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "bucket": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "object_path": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 1024
+        },
+        "mime_type": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "filename": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "size_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483648
+        },
+        "sha256": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "ready",
+            "expired"
+          ]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "finalized_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "download_url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "preview_url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.schemas.get.response.v1.json
+++ b/schemas/public_api/api.schemas.get.response.v1.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.schemas.get.response.v1.json",
+  "title": "ApiSchemasGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "schema"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "semantic_type",
+        "schema_ref",
+        "schema_hash",
+        "compatibility_mode",
+        "scope",
+        "owner_agent",
+        "active",
+        "schema_json",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "semantic_type": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]+(?:\\.[a-z0-9_]+){2,}\\.v[0-9]+$"
+        },
+        "schema_ref": {
+          "type": "string",
+          "maxLength": 512
+        },
+        "schema_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "compatibility_mode": {
+          "type": "string",
+          "enum": [
+            "strict",
+            "backward",
+            "warn"
+          ]
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "tenant",
+            "core"
+          ]
+        },
+        "owner_agent": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "schema_json": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.schemas.upsert.request.v1.json
+++ b/schemas/public_api/api.schemas.upsert.request.v1.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.schemas.upsert.request.v1.json",
+  "title": "ApiSchemasUpsertRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "semantic_type",
+    "schema_json",
+    "compatibility_mode"
+  ],
+  "properties": {
+    "semantic_type": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+(?:\\.[a-z0-9_]+){2,}\\.v[0-9]+$"
+    },
+    "schema_json": {
+      "type": "object"
+    },
+    "schema_ref": {
+      "type": "string",
+      "maxLength": 512
+    },
+    "compatibility_mode": {
+      "type": "string",
+      "enum": [
+        "strict",
+        "backward",
+        "warn"
+      ]
+    },
+    "scope": {
+      "type": "string",
+      "enum": [
+        "tenant",
+        "core"
+      ]
+    },
+    "active": {
+      "type": "boolean"
+    }
+  }
+}

--- a/schemas/public_api/api.schemas.upsert.response.v1.json
+++ b/schemas/public_api/api.schemas.upsert.response.v1.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.schemas.upsert.response.v1.json",
+  "title": "ApiSchemasUpsertResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "schema"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "semantic_type",
+        "schema_ref",
+        "schema_hash",
+        "compatibility_mode",
+        "scope",
+        "owner_agent",
+        "active",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "semantic_type": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]+(?:\\.[a-z0-9_]+){2,}\\.v[0-9]+$"
+        },
+        "schema_ref": {
+          "type": "string",
+          "maxLength": 512
+        },
+        "schema_hash": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "compatibility_mode": {
+          "type": "string",
+          "enum": [
+            "strict",
+            "backward",
+            "warn"
+          ]
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "tenant",
+            "core"
+          ]
+        },
+        "owner_agent": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Continue Track B by migrating the remaining `public_api` contract groups into `axme-spec`.
- Add 13 schema files covering `invites`, `media`, and `schemas` endpoints.
- Update `README.md` extraction scope to include the new public API sets.

## Test plan
- [x] `python3 scripts/validate_schemas.py`
- [x] `python3 -c \"from pathlib import Path; from scripts.validate_schemas import validate_schema_documents; root=Path('.').resolve(); errors=validate_schema_documents(root); assert errors==[], errors; print('pytest-equivalent check passed')\"`
- [ ] CI (`.github/workflows/ci.yml`) passes in PR


Made with [Cursor](https://cursor.com)