### PR TITLE
feat: add intent resolve API schemas

### DIFF
--- a/docs/public-api-schema-index.md
+++ b/docs/public-api-schema-index.md
@@ -21,6 +21,8 @@ Related artifacts:
 - `schemas/public_api/api.intents.create.response.v1.json`
 - `schemas/public_api/api.intents.get.response.v1.json`
 - `schemas/public_api/api.intents.events.list.response.v1.json`
+- `schemas/public_api/api.intents.resolve.request.v1.json`
+- `schemas/public_api/api.intents.resolve.response.v1.json`
 - `schemas/public_api/api.approvals.decision.request.v1.json`
 - `schemas/public_api/api.approvals.decision.response.v1.json`
 - `schemas/public_api/api.webhooks.events.request.v1.json`
@@ -70,6 +72,12 @@ Related artifacts:
   - response: `api.intents.get.response.v1.json`
 - `GET /v1/intents/{intent_id}/events`
   - response: `api.intents.events.list.response.v1.json`
+- `POST /v1/intents/{intent_id}/resolve`
+  - request: `api.intents.resolve.request.v1.json`
+  - response: `api.intents.resolve.response.v1.json`
+- `GET /v1/intents/{intent_id}/events/stream`
+  - transport: `text/event-stream` (SSE)
+  - event payload shape: same event object as `api.intents.events.list.response.v1.json` item
 - `POST /v1/approvals/{approval_id}/decision`
   - request: `api.approvals.decision.request.v1.json`
   - response: `api.approvals.decision.response.v1.json`

--- a/docs/schema-versioning-rules.md
+++ b/docs/schema-versioning-rules.md
@@ -48,6 +48,8 @@ Rules apply to:
 - `api.intents.create.response.v1.json`
 - `api.intents.get.response.v1.json`
 - `api.intents.events.list.response.v1.json`
+- `api.intents.resolve.request.v1.json`
+- `api.intents.resolve.response.v1.json`
 - `api.approvals.decision.request.v1.json`
 - `api.approvals.decision.response.v1.json`
 - `api.webhooks.events.request.v1.json`

--- a/schemas/public_api/api.intents.resolve.request.v1.json
+++ b/schemas/public_api/api.intents.resolve.request.v1.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.intents.resolve.request.v1.json",
+  "title": "ApiIntentsResolveRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "status"
+  ],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "COMPLETED",
+        "FAILED",
+        "CANCELED"
+      ]
+    },
+    "actor": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "result": {
+      "type": "object"
+    },
+    "error": {
+      "type": "object"
+    },
+    "reason": {
+      "type": "string",
+      "maxLength": 2000
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "COMPLETED"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "result"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "FAILED"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "error"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "CANCELED"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "reason"
+        ]
+      }
+    }
+  ]
+}

--- a/schemas/public_api/api.intents.resolve.response.v1.json
+++ b/schemas/public_api/api.intents.resolve.response.v1.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.intents.resolve.response.v1.json",
+  "title": "ApiIntentsResolveResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "intent",
+    "event",
+    "completion_delivery"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "intent": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "intent_id",
+        "status",
+        "created_at",
+        "intent_type",
+        "correlation_id",
+        "from_agent",
+        "to_agent",
+        "payload"
+      ],
+      "properties": {
+        "intent_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "status": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "intent_type": {
+          "type": "string"
+        },
+        "correlation_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "from_agent": {
+          "type": "string"
+        },
+        "to_agent": {
+          "type": "string"
+        },
+        "reply_to": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "payload": {
+          "type": "object"
+        }
+      }
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "intent_id",
+        "seq",
+        "event_type",
+        "status",
+        "at",
+        "details"
+      ],
+      "properties": {
+        "intent_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "seq": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "event_type": {
+          "type": "string",
+          "enum": [
+            "intent.completed",
+            "intent.failed",
+            "intent.canceled"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "COMPLETED",
+            "FAILED",
+            "CANCELED"
+          ]
+        },
+        "waiting_reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "WAITING_FOR_HUMAN",
+            "WAITING_FOR_TOOL",
+            "WAITING_FOR_AGENT",
+            "WAITING_FOR_TIME",
+            null
+          ]
+        },
+        "handler": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "actor": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "details": {
+          "type": "object"
+        }
+      }
+    },
+    "completion_delivery": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "delivered"
+      ],
+      "properties": {
+        "delivered": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "reply_to": {
+          "type": "string"
+        },
+        "thread_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "message_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "completion": {
+          "type": "object"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `api.intents.resolve.request.v1.json` for terminal lifecycle resolution payloads (`COMPLETED|FAILED|CANCELED`)
- add `api.intents.resolve.response.v1.json` for resolved intent projection, terminal event, and completion delivery metadata
- register resolve endpoint contracts in schema index/versioning docs, including stream payload mapping note

## Test plan
- [x] `"/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python" -m pytest`

Made with [Cursor](https://cursor.com)