### PR TITLE
feat: F1.1 add enterprise schema families for Track F

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,29 @@ Track B extraction in progress.
   - `schemas/public_api/api.schemas.upsert.request.v1.json`
   - `schemas/public_api/api.schemas.upsert.response.v1.json`
   - `schemas/public_api/api.schemas.get.response.v1.json`
+- Public API schemas (enterprise access set, Track F phase 1):
+  - `schemas/public_api/api.organizations.create.request.v1.json`
+  - `schemas/public_api/api.organizations.create.response.v1.json`
+  - `schemas/public_api/api.organizations.get.response.v1.json`
+  - `schemas/public_api/api.organizations.update.request.v1.json`
+  - `schemas/public_api/api.organizations.update.response.v1.json`
+  - `schemas/public_api/api.organizations.workspaces.create.request.v1.json`
+  - `schemas/public_api/api.organizations.workspaces.create.response.v1.json`
+  - `schemas/public_api/api.organizations.workspaces.list.response.v1.json`
+  - `schemas/public_api/api.organizations.workspaces.update.request.v1.json`
+  - `schemas/public_api/api.organizations.workspaces.update.response.v1.json`
+  - `schemas/public_api/api.organizations.members.list.response.v1.json`
+  - `schemas/public_api/api.organizations.members.add.request.v1.json`
+  - `schemas/public_api/api.organizations.members.add.response.v1.json`
+  - `schemas/public_api/api.organizations.members.update.request.v1.json`
+  - `schemas/public_api/api.organizations.members.update.response.v1.json`
+  - `schemas/public_api/api.organizations.members.remove.response.v1.json`
+  - `schemas/public_api/api.access_requests.create.request.v1.json`
+  - `schemas/public_api/api.access_requests.create.response.v1.json`
+  - `schemas/public_api/api.access_requests.list.response.v1.json`
+  - `schemas/public_api/api.access_requests.get.response.v1.json`
+  - `schemas/public_api/api.access_requests.review.request.v1.json`
+  - `schemas/public_api/api.access_requests.review.response.v1.json`
 - Schema validation script, tests, and CI gate
 
 ## Development

--- a/docs/public-api-schema-index.md
+++ b/docs/public-api-schema-index.md
@@ -164,3 +164,69 @@ Related artifacts:
   - response: `api.media.finalize_upload.response.v1.json`
 - `GET /v1/media/{upload_id}`
   - response: `api.media.get.response.v1.json`
+
+## Track F Phase 1 Families (Draft Contracts)
+
+### Files
+
+- `schemas/public_api/api.organizations.create.request.v1.json`
+- `schemas/public_api/api.organizations.create.response.v1.json`
+- `schemas/public_api/api.organizations.get.response.v1.json`
+- `schemas/public_api/api.organizations.update.request.v1.json`
+- `schemas/public_api/api.organizations.update.response.v1.json`
+- `schemas/public_api/api.organizations.workspaces.create.request.v1.json`
+- `schemas/public_api/api.organizations.workspaces.create.response.v1.json`
+- `schemas/public_api/api.organizations.workspaces.list.response.v1.json`
+- `schemas/public_api/api.organizations.workspaces.update.request.v1.json`
+- `schemas/public_api/api.organizations.workspaces.update.response.v1.json`
+- `schemas/public_api/api.organizations.members.list.response.v1.json`
+- `schemas/public_api/api.organizations.members.add.request.v1.json`
+- `schemas/public_api/api.organizations.members.add.response.v1.json`
+- `schemas/public_api/api.organizations.members.update.request.v1.json`
+- `schemas/public_api/api.organizations.members.update.response.v1.json`
+- `schemas/public_api/api.organizations.members.remove.response.v1.json`
+- `schemas/public_api/api.access_requests.create.request.v1.json`
+- `schemas/public_api/api.access_requests.create.response.v1.json`
+- `schemas/public_api/api.access_requests.list.response.v1.json`
+- `schemas/public_api/api.access_requests.get.response.v1.json`
+- `schemas/public_api/api.access_requests.review.request.v1.json`
+- `schemas/public_api/api.access_requests.review.response.v1.json`
+
+### Planned Endpoint Mapping
+
+- `POST /v1/organizations`
+  - request: `api.organizations.create.request.v1.json`
+  - response: `api.organizations.create.response.v1.json`
+- `GET /v1/organizations/{org_id}`
+  - response: `api.organizations.get.response.v1.json`
+- `PATCH /v1/organizations/{org_id}`
+  - request: `api.organizations.update.request.v1.json`
+  - response: `api.organizations.update.response.v1.json`
+- `POST /v1/organizations/{org_id}/workspaces`
+  - request: `api.organizations.workspaces.create.request.v1.json`
+  - response: `api.organizations.workspaces.create.response.v1.json`
+- `GET /v1/organizations/{org_id}/workspaces`
+  - response: `api.organizations.workspaces.list.response.v1.json`
+- `PATCH /v1/organizations/{org_id}/workspaces/{workspace_id}`
+  - request: `api.organizations.workspaces.update.request.v1.json`
+  - response: `api.organizations.workspaces.update.response.v1.json`
+- `GET /v1/organizations/{org_id}/members`
+  - response: `api.organizations.members.list.response.v1.json`
+- `POST /v1/organizations/{org_id}/members`
+  - request: `api.organizations.members.add.request.v1.json`
+  - response: `api.organizations.members.add.response.v1.json`
+- `PATCH /v1/organizations/{org_id}/members/{member_id}`
+  - request: `api.organizations.members.update.request.v1.json`
+  - response: `api.organizations.members.update.response.v1.json`
+- `DELETE /v1/organizations/{org_id}/members/{member_id}`
+  - response: `api.organizations.members.remove.response.v1.json`
+- `POST /v1/access-requests`
+  - request: `api.access_requests.create.request.v1.json`
+  - response: `api.access_requests.create.response.v1.json`
+- `GET /v1/access-requests`
+  - response: `api.access_requests.list.response.v1.json`
+- `GET /v1/access-requests/{access_request_id}`
+  - response: `api.access_requests.get.response.v1.json`
+- `POST /v1/access-requests/{access_request_id}/review`
+  - request: `api.access_requests.review.request.v1.json`
+  - response: `api.access_requests.review.response.v1.json`

--- a/schemas/public_api/api.access_requests.create.request.v1.json
+++ b/schemas/public_api/api.access_requests.create.request.v1.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.access_requests.create.request.v1.json",
+  "title": "ApiAccessRequestsCreateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "request_type",
+    "requester_actor_id"
+  ],
+  "properties": {
+    "request_type": {
+      "type": "string",
+      "enum": [
+        "create_organization",
+        "join_organization",
+        "elevated_role"
+      ]
+    },
+    "requester_actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "workspace_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "requested_role": {
+      "type": "string",
+      "enum": [
+        "org_owner",
+        "org_admin",
+        "workspace_admin",
+        "member",
+        "billing_viewer",
+        "security_auditor"
+      ]
+    },
+    "company_name": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 255
+    },
+    "justification": {
+      "type": "string",
+      "maxLength": 4000
+    }
+  }
+}

--- a/schemas/public_api/api.access_requests.create.response.v1.json
+++ b/schemas/public_api/api.access_requests.create.response.v1.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.access_requests.create.response.v1.json",
+  "title": "ApiAccessRequestsCreateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "access_request"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "access_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "access_request_id",
+        "request_type",
+        "state",
+        "requester_actor_id",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "access_request_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "request_type": {
+          "type": "string",
+          "enum": [
+            "create_organization",
+            "join_organization",
+            "elevated_role"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "under_review",
+            "approved",
+            "rejected",
+            "waitlisted",
+            "expired"
+          ]
+        },
+        "requester_actor_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "org_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
+        "requested_role": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "org_owner",
+            "org_admin",
+            "workspace_admin",
+            "member",
+            "billing_viewer",
+            "security_auditor",
+            null
+          ]
+        },
+        "company_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 255
+        },
+        "justification": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 4000
+        },
+        "reviewer_actor_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "review_comment": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 4000
+        },
+        "reviewed_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.access_requests.get.response.v1.json
+++ b/schemas/public_api/api.access_requests.get.response.v1.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.access_requests.get.response.v1.json",
+  "title": "ApiAccessRequestsGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "access_request"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "access_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "access_request_id",
+        "request_type",
+        "state",
+        "requester_actor_id",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "access_request_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "request_type": {
+          "type": "string",
+          "enum": [
+            "create_organization",
+            "join_organization",
+            "elevated_role"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "under_review",
+            "approved",
+            "rejected",
+            "waitlisted",
+            "expired"
+          ]
+        },
+        "requester_actor_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "org_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
+        "requested_role": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "org_owner",
+            "org_admin",
+            "workspace_admin",
+            "member",
+            "billing_viewer",
+            "security_auditor",
+            null
+          ]
+        },
+        "company_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 255
+        },
+        "justification": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 4000
+        },
+        "reviewer_actor_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "review_comment": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 4000
+        },
+        "reviewed_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.access_requests.list.response.v1.json
+++ b/schemas/public_api/api.access_requests.list.response.v1.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.access_requests.list.response.v1.json",
+  "title": "ApiAccessRequestsListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "access_requests"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "access_requests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "access_request_id",
+          "request_type",
+          "state",
+          "requester_actor_id",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "access_request_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "request_type": {
+            "type": "string",
+            "enum": [
+              "create_organization",
+              "join_organization",
+              "elevated_role"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "under_review",
+              "approved",
+              "rejected",
+              "waitlisted",
+              "expired"
+            ]
+          },
+          "requester_actor_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "org_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "workspace_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "requested_role": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "org_owner",
+              "org_admin",
+              "workspace_admin",
+              "member",
+              "billing_viewer",
+              "security_auditor",
+              null
+            ]
+          },
+          "company_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 2,
+            "maxLength": 255
+          },
+          "justification": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4000
+          },
+          "reviewer_actor_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "review_comment": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 4000
+          },
+          "reviewed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.access_requests.review.request.v1.json
+++ b/schemas/public_api/api.access_requests.review.request.v1.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.access_requests.review.request.v1.json",
+  "title": "ApiAccessRequestsReviewRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "decision",
+    "reviewer_actor_id"
+  ],
+  "properties": {
+    "decision": {
+      "type": "string",
+      "enum": [
+        "approve",
+        "reject",
+        "waitlist"
+      ]
+    },
+    "reviewer_actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "review_comment": {
+      "type": "string",
+      "maxLength": 4000
+    }
+  }
+}

--- a/schemas/public_api/api.access_requests.review.response.v1.json
+++ b/schemas/public_api/api.access_requests.review.response.v1.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.access_requests.review.response.v1.json",
+  "title": "ApiAccessRequestsReviewResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "access_request"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "access_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "access_request_id",
+        "request_type",
+        "state",
+        "requester_actor_id",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "access_request_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "request_type": {
+          "type": "string",
+          "enum": [
+            "create_organization",
+            "join_organization",
+            "elevated_role"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "under_review",
+            "approved",
+            "rejected",
+            "waitlisted",
+            "expired"
+          ]
+        },
+        "requester_actor_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "org_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
+        "requested_role": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "org_owner",
+            "org_admin",
+            "workspace_admin",
+            "member",
+            "billing_viewer",
+            "security_auditor",
+            null
+          ]
+        },
+        "company_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 255
+        },
+        "justification": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 4000
+        },
+        "reviewer_actor_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "review_comment": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 4000
+        },
+        "reviewed_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.create.request.v1.json
+++ b/schemas/public_api/api.organizations.create.request.v1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.create.request.v1.json",
+  "title": "ApiOrganizationsCreateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "requested_by_actor_id"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 120
+    },
+    "legal_name": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 255
+    },
+    "primary_domain": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "requested_by_actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "metadata": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.create.response.v1.json
+++ b/schemas/public_api/api.organizations.create.response.v1.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.create.response.v1.json",
+  "title": "ApiOrganizationsCreateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "organization"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "organization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "org_id",
+        "name",
+        "status",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "legal_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 255
+        },
+        "primary_domain": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "active",
+            "suspended",
+            "archived"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.get.response.v1.json
+++ b/schemas/public_api/api.organizations.get.response.v1.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.get.response.v1.json",
+  "title": "ApiOrganizationsGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "organization"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "organization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "org_id",
+        "name",
+        "status",
+        "created_at",
+        "updated_at",
+        "workspaces_count",
+        "members_count"
+      ],
+      "properties": {
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "legal_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 255
+        },
+        "primary_domain": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "active",
+            "suspended",
+            "archived"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "workspaces_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "members_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.members.add.request.v1.json
+++ b/schemas/public_api/api.organizations.members.add.request.v1.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.members.add.request.v1.json",
+  "title": "ApiOrganizationsMembersAddRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id",
+    "actor_id",
+    "role"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "workspace_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "role": {
+      "type": "string",
+      "enum": [
+        "org_owner",
+        "org_admin",
+        "workspace_admin",
+        "member",
+        "billing_viewer",
+        "security_auditor"
+      ]
+    },
+    "invited_by_actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.members.add.response.v1.json
+++ b/schemas/public_api/api.organizations.members.add.response.v1.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.members.add.response.v1.json",
+  "title": "ApiOrganizationsMembersAddResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "member"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "member": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "member_id",
+        "org_id",
+        "actor_id",
+        "role",
+        "status",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "member_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
+        "actor_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "org_owner",
+            "org_admin",
+            "workspace_admin",
+            "member",
+            "billing_viewer",
+            "security_auditor"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "invited",
+            "suspended",
+            "removed"
+          ]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.members.list.response.v1.json
+++ b/schemas/public_api/api.organizations.members.list.response.v1.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.members.list.response.v1.json",
+  "title": "ApiOrganizationsMembersListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "members"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "members": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "member_id",
+          "org_id",
+          "actor_id",
+          "role",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "member_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "org_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "workspace_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid"
+          },
+          "actor_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "org_owner",
+              "org_admin",
+              "workspace_admin",
+              "member",
+              "billing_viewer",
+              "security_auditor"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "invited",
+              "suspended",
+              "removed"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.members.remove.response.v1.json
+++ b/schemas/public_api/api.organizations.members.remove.response.v1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.members.remove.response.v1.json",
+  "title": "ApiOrganizationsMembersRemoveResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "removed",
+    "org_id",
+    "member_id",
+    "removed_at"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "removed": {
+      "type": "boolean",
+      "const": true
+    },
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "member_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "removed_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.members.update.request.v1.json
+++ b/schemas/public_api/api.organizations.members.update.request.v1.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.members.update.request.v1.json",
+  "title": "ApiOrganizationsMembersUpdateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id",
+    "member_id"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "member_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "workspace_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "role": {
+      "type": "string",
+      "enum": [
+        "org_owner",
+        "org_admin",
+        "workspace_admin",
+        "member",
+        "billing_viewer",
+        "security_auditor"
+      ]
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "invited",
+        "suspended",
+        "removed"
+      ]
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.members.update.response.v1.json
+++ b/schemas/public_api/api.organizations.members.update.response.v1.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.members.update.response.v1.json",
+  "title": "ApiOrganizationsMembersUpdateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "member"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "member": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "member_id",
+        "org_id",
+        "actor_id",
+        "role",
+        "status",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "member_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uuid"
+        },
+        "actor_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "org_owner",
+            "org_admin",
+            "workspace_admin",
+            "member",
+            "billing_viewer",
+            "security_auditor"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "invited",
+            "suspended",
+            "removed"
+          ]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.update.request.v1.json
+++ b/schemas/public_api/api.organizations.update.request.v1.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.update.request.v1.json",
+  "title": "ApiOrganizationsUpdateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 120
+    },
+    "legal_name": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 255
+    },
+    "primary_domain": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "active",
+        "suspended",
+        "archived"
+      ]
+    },
+    "metadata": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.update.response.v1.json
+++ b/schemas/public_api/api.organizations.update.response.v1.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.update.response.v1.json",
+  "title": "ApiOrganizationsUpdateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "organization"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "organization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "org_id",
+        "name",
+        "status",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "legal_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 255
+        },
+        "primary_domain": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "active",
+            "suspended",
+            "archived"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.workspaces.create.request.v1.json
+++ b/schemas/public_api/api.organizations.workspaces.create.request.v1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.workspaces.create.request.v1.json",
+  "title": "ApiOrganizationsWorkspacesCreateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id",
+    "name",
+    "environment"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 120
+    },
+    "environment": {
+      "type": "string",
+      "enum": [
+        "sandbox",
+        "staging",
+        "production"
+      ]
+    },
+    "region": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 64
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.workspaces.create.response.v1.json
+++ b/schemas/public_api/api.organizations.workspaces.create.response.v1.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.workspaces.create.response.v1.json",
+  "title": "ApiOrganizationsWorkspacesCreateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "workspace"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workspace_id",
+        "org_id",
+        "name",
+        "environment",
+        "status",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "environment": {
+          "type": "string",
+          "enum": [
+            "sandbox",
+            "staging",
+            "production"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "suspended",
+            "archived"
+          ]
+        },
+        "region": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 64
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.workspaces.list.response.v1.json
+++ b/schemas/public_api/api.organizations.workspaces.list.response.v1.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.workspaces.list.response.v1.json",
+  "title": "ApiOrganizationsWorkspacesListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "workspaces"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "workspaces": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "workspace_id",
+          "org_id",
+          "name",
+          "environment",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "workspace_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "org_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 120
+          },
+          "environment": {
+            "type": "string",
+            "enum": [
+              "sandbox",
+              "staging",
+              "production"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "suspended",
+              "archived"
+            ]
+          },
+          "region": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "minLength": 2,
+            "maxLength": 64
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.workspaces.update.request.v1.json
+++ b/schemas/public_api/api.organizations.workspaces.update.request.v1.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.workspaces.update.request.v1.json",
+  "title": "ApiOrganizationsWorkspacesUpdateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id",
+    "workspace_id"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "workspace_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 120
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "suspended",
+        "archived"
+      ]
+    },
+    "region": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 64
+    }
+  }
+}

--- a/schemas/public_api/api.organizations.workspaces.update.response.v1.json
+++ b/schemas/public_api/api.organizations.workspaces.update.response.v1.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.organizations.workspaces.update.response.v1.json",
+  "title": "ApiOrganizationsWorkspacesUpdateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "workspace"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workspace_id",
+        "org_id",
+        "name",
+        "environment",
+        "status",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "environment": {
+          "type": "string",
+          "enum": [
+            "sandbox",
+            "staging",
+            "production"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "suspended",
+            "archived"
+          ]
+        },
+        "region": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 64
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Track F phase-1 public API schema families for `organizations.*`, `organizations.workspaces.*`, `organizations.members.*`, and `access_requests.*`
- include request/response contracts for create/get/update/list/review operations needed by Sprint 1 F1.1
- update `README.md` and `docs/public-api-schema-index.md` with new schema inventory and planned endpoint mapping

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python scripts/validate_schemas.py`
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest`

Made with [Cursor](https://cursor.com)