### PR TITLE
feat: F1.2 add quota and usage schema contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Track B extraction in progress.
   - `schemas/public_api/api.access_requests.get.response.v1.json`
   - `schemas/public_api/api.access_requests.review.request.v1.json`
   - `schemas/public_api/api.access_requests.review.response.v1.json`
+- Public API schemas (quota and usage set, Track F phase 1):
+  - `schemas/public_api/api.quotas.get.response.v1.json`
+  - `schemas/public_api/api.quotas.update.request.v1.json`
+  - `schemas/public_api/api.quotas.update.response.v1.json`
+  - `schemas/public_api/api.usage.summary.get.response.v1.json`
+  - `schemas/public_api/api.usage.timeseries.get.response.v1.json`
 - Schema validation script, tests, and CI gate
 
 ## Development

--- a/docs/public-api-schema-index.md
+++ b/docs/public-api-schema-index.md
@@ -230,3 +230,25 @@ Related artifacts:
 - `POST /v1/access-requests/{access_request_id}/review`
   - request: `api.access_requests.review.request.v1.json`
   - response: `api.access_requests.review.response.v1.json`
+
+## Track F Phase 1 Quota and Usage Families (Draft Contracts)
+
+### Files
+
+- `schemas/public_api/api.quotas.get.response.v1.json`
+- `schemas/public_api/api.quotas.update.request.v1.json`
+- `schemas/public_api/api.quotas.update.response.v1.json`
+- `schemas/public_api/api.usage.summary.get.response.v1.json`
+- `schemas/public_api/api.usage.timeseries.get.response.v1.json`
+
+### Planned Endpoint Mapping
+
+- `GET /v1/quotas?org_id=...&workspace_id=...`
+  - response: `api.quotas.get.response.v1.json`
+- `PATCH /v1/quotas`
+  - request: `api.quotas.update.request.v1.json`
+  - response: `api.quotas.update.response.v1.json`
+- `GET /v1/usage/summary?org_id=...&workspace_id=...`
+  - response: `api.usage.summary.get.response.v1.json`
+- `GET /v1/usage/timeseries?org_id=...&workspace_id=...`
+  - response: `api.usage.timeseries.get.response.v1.json`

--- a/schemas/public_api/api.quotas.get.response.v1.json
+++ b/schemas/public_api/api.quotas.get.response.v1.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.quotas.get.response.v1.json",
+  "title": "ApiQuotasGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "quota_policy"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "quota_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "quota_policy_id",
+        "org_id",
+        "workspace_id",
+        "dimensions",
+        "soft_threshold_percent",
+        "overage_mode",
+        "updated_at"
+      ],
+      "properties": {
+        "quota_policy_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "dimensions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "requests_per_minute",
+            "intents_per_day",
+            "inbox_writes_per_day",
+            "media_upload_bytes_per_day",
+            "media_storage_bytes",
+            "webhook_deliveries_per_day",
+            "schema_writes_per_day"
+          ],
+          "properties": {
+            "requests_per_minute": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "intents_per_day": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "inbox_writes_per_day": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "media_upload_bytes_per_day": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "media_storage_bytes": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "webhook_deliveries_per_day": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "schema_writes_per_day": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "soft_threshold_percent": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "hard_enforcement": {
+          "type": "boolean"
+        },
+        "overage_mode": {
+          "type": "string",
+          "enum": [
+            "block",
+            "grace",
+            "bill_overage"
+          ]
+        },
+        "updated_by_actor_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.quotas.update.request.v1.json
+++ b/schemas/public_api/api.quotas.update.request.v1.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.quotas.update.request.v1.json",
+  "title": "ApiQuotasUpdateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id",
+    "workspace_id",
+    "dimensions",
+    "overage_mode",
+    "updated_by_actor_id"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "workspace_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requests_per_minute",
+        "intents_per_day",
+        "inbox_writes_per_day",
+        "media_upload_bytes_per_day",
+        "media_storage_bytes",
+        "webhook_deliveries_per_day",
+        "schema_writes_per_day"
+      ],
+      "properties": {
+        "requests_per_minute": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "intents_per_day": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "inbox_writes_per_day": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "media_upload_bytes_per_day": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "media_storage_bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "webhook_deliveries_per_day": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "schema_writes_per_day": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "soft_threshold_percent": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 100
+    },
+    "hard_enforcement": {
+      "type": "boolean"
+    },
+    "overage_mode": {
+      "type": "string",
+      "enum": [
+        "block",
+        "grace",
+        "bill_overage"
+      ]
+    },
+    "updated_by_actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    }
+  }
+}

--- a/schemas/public_api/api.quotas.update.response.v1.json
+++ b/schemas/public_api/api.quotas.update.response.v1.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.quotas.update.response.v1.json",
+  "title": "ApiQuotasUpdateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "quota_policy"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "quota_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "quota_policy_id",
+        "org_id",
+        "workspace_id",
+        "dimensions",
+        "soft_threshold_percent",
+        "overage_mode",
+        "updated_at"
+      ],
+      "properties": {
+        "quota_policy_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "dimensions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "requests_per_minute",
+            "intents_per_day",
+            "inbox_writes_per_day",
+            "media_upload_bytes_per_day",
+            "media_storage_bytes",
+            "webhook_deliveries_per_day",
+            "schema_writes_per_day"
+          ],
+          "properties": {
+            "requests_per_minute": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "intents_per_day": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "inbox_writes_per_day": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "media_upload_bytes_per_day": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "media_storage_bytes": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "webhook_deliveries_per_day": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "schema_writes_per_day": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "soft_threshold_percent": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "hard_enforcement": {
+          "type": "boolean"
+        },
+        "overage_mode": {
+          "type": "string",
+          "enum": [
+            "block",
+            "grace",
+            "bill_overage"
+          ]
+        },
+        "updated_by_actor_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.usage.summary.get.response.v1.json
+++ b/schemas/public_api/api.usage.summary.get.response.v1.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.usage.summary.get.response.v1.json",
+  "title": "ApiUsageSummaryGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "summary"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "org_id",
+        "workspace_id",
+        "window_start",
+        "window_end",
+        "dimensions"
+      ],
+      "properties": {
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "window_start": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "window_end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "dimensions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "requests_per_minute",
+            "intents_per_day",
+            "inbox_writes_per_day",
+            "media_upload_bytes_per_day",
+            "media_storage_bytes",
+            "webhook_deliveries_per_day",
+            "schema_writes_per_day"
+          ],
+          "properties": {
+            "requests_per_minute": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "used",
+                "limit",
+                "remaining"
+              ],
+              "properties": {
+                "used": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "limit": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "remaining": {
+                  "type": "integer"
+                }
+              }
+            },
+            "intents_per_day": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "used",
+                "limit",
+                "remaining"
+              ],
+              "properties": {
+                "used": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "limit": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "remaining": {
+                  "type": "integer"
+                }
+              }
+            },
+            "inbox_writes_per_day": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "used",
+                "limit",
+                "remaining"
+              ],
+              "properties": {
+                "used": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "limit": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "remaining": {
+                  "type": "integer"
+                }
+              }
+            },
+            "media_upload_bytes_per_day": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "used",
+                "limit",
+                "remaining"
+              ],
+              "properties": {
+                "used": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "limit": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "remaining": {
+                  "type": "integer"
+                }
+              }
+            },
+            "media_storage_bytes": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "used",
+                "limit",
+                "remaining"
+              ],
+              "properties": {
+                "used": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "limit": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "remaining": {
+                  "type": "integer"
+                }
+              }
+            },
+            "webhook_deliveries_per_day": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "used",
+                "limit",
+                "remaining"
+              ],
+              "properties": {
+                "used": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "limit": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "remaining": {
+                  "type": "integer"
+                }
+              }
+            },
+            "schema_writes_per_day": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "used",
+                "limit",
+                "remaining"
+              ],
+              "properties": {
+                "used": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "limit": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "remaining": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.usage.timeseries.get.response.v1.json
+++ b/schemas/public_api/api.usage.timeseries.get.response.v1.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.usage.timeseries.get.response.v1.json",
+  "title": "ApiUsageTimeseriesGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "series"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "series": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "org_id",
+        "workspace_id",
+        "granularity",
+        "points"
+      ],
+      "properties": {
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "granularity": {
+          "type": "string",
+          "enum": [
+            "hour",
+            "day"
+          ]
+        },
+        "points": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "at",
+              "dimensions"
+            ],
+            "properties": {
+              "at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "dimensions": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "requests_per_minute",
+                  "intents_per_day",
+                  "inbox_writes_per_day",
+                  "media_upload_bytes_per_day",
+                  "media_storage_bytes",
+                  "webhook_deliveries_per_day",
+                  "schema_writes_per_day"
+                ],
+                "properties": {
+                  "requests_per_minute": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "intents_per_day": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "inbox_writes_per_day": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "media_upload_bytes_per_day": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "media_storage_bytes": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "webhook_deliveries_per_day": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "schema_writes_per_day": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `quotas.*` public API schemas for quota policy retrieval and updates
- add usage aggregation contract schemas for `usage.summary.get` and `usage.timeseries.get`
- update schema inventory docs with new Track F quota/usage files and planned endpoint mappings

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python scripts/validate_schemas.py`
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest`

Made with [Cursor](https://cursor.com)