### PR TITLE
feat: align intent status schemas with canonical lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Track B extraction in progress.
   - `schemas/public_api/api.intents.create.request.v1.json`
   - `schemas/public_api/api.intents.create.response.v1.json`
   - `schemas/public_api/api.intents.get.response.v1.json`
+  - `schemas/public_api/api.intents.events.list.response.v1.json`
+  - `schemas/public_api/api.intents.resolve.request.v1.json`
+  - `schemas/public_api/api.intents.resolve.response.v1.json`
   - `schemas/public_api/api.approvals.decision.request.v1.json`
   - `schemas/public_api/api.approvals.decision.response.v1.json`
   - `schemas/public_api/api.capabilities.get.response.v1.json`

--- a/docs/public-api-schema-index.md
+++ b/docs/public-api-schema-index.md
@@ -10,6 +10,11 @@ Intent lifecycle baseline (durable execution semantics) is defined in:
 - `schemas/protocol/intent.lifecycle.v1.json`
 - `schemas/protocol/intent.event.v1.json`
 
+Public API status projection rule:
+
+- `intent.status` is canonical lifecycle status (`CREATED` -> terminal).
+- `intent.legacy_status` is optional compatibility projection for legacy clients.
+
 Related artifacts:
 
 - OpenAPI export: `docs/openapi/gateway.v1.json`

--- a/schemas/public_api/api.intents.create.response.v1.json
+++ b/schemas/public_api/api.intents.create.response.v1.json
@@ -22,11 +22,15 @@
     "status": {
       "type": "string",
       "enum": [
-        "accepted",
-        "running",
-        "blocked",
-        "done",
-        "failed"
+        "CREATED",
+        "SUBMITTED",
+        "DELIVERED",
+        "ACKNOWLEDGED",
+        "IN_PROGRESS",
+        "WAITING",
+        "COMPLETED",
+        "FAILED",
+        "CANCELED"
       ]
     },
     "created_at": {

--- a/schemas/public_api/api.intents.get.response.v1.json
+++ b/schemas/public_api/api.intents.get.response.v1.json
@@ -32,7 +32,28 @@
           "format": "uuid"
         },
         "status": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "CREATED",
+            "SUBMITTED",
+            "DELIVERED",
+            "ACKNOWLEDGED",
+            "IN_PROGRESS",
+            "WAITING",
+            "COMPLETED",
+            "FAILED",
+            "CANCELED"
+          ]
+        },
+        "legacy_status": {
+          "type": "string",
+          "enum": [
+            "accepted",
+            "running",
+            "blocked",
+            "done",
+            "failed"
+          ]
         },
         "created_at": {
           "type": "string",

--- a/schemas/public_api/api.intents.resolve.response.v1.json
+++ b/schemas/public_api/api.intents.resolve.response.v1.json
@@ -34,7 +34,19 @@
           "format": "uuid"
         },
         "status": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "COMPLETED",
+            "FAILED",
+            "CANCELED"
+          ]
+        },
+        "legacy_status": {
+          "type": "string",
+          "enum": [
+            "done",
+            "failed"
+          ]
         },
         "created_at": {
           "type": "string",


### PR DESCRIPTION
## Summary
- switch `api.intents.create.response.v1.json` status enum to canonical lifecycle statuses
- make `api.intents.get.response.v1.json` `intent.status` canonical and add optional `intent.legacy_status` compatibility projection
- constrain `api.intents.resolve.response.v1.json` intent status to terminal canonical states and document status projection rules

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python scripts/validate_schemas.py`
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest`

Made with [Cursor](https://cursor.com)