### PR TITLE
feat: add service-account contract schemas for Track F

### DIFF
--- a/docs/public-api-schema-index.md
+++ b/docs/public-api-schema-index.md
@@ -257,3 +257,30 @@ Related artifacts:
   - response: `api.usage.summary.get.response.v1.json`
 - `GET /v1/usage/timeseries?org_id=...&workspace_id=...`
   - response: `api.usage.timeseries.get.response.v1.json`
+
+## Track F Phase 2 Service Accounts Families (Draft Contracts)
+
+### Files
+
+- `schemas/public_api/api.service_accounts.create.request.v1.json`
+- `schemas/public_api/api.service_accounts.create.response.v1.json`
+- `schemas/public_api/api.service_accounts.list.response.v1.json`
+- `schemas/public_api/api.service_accounts.get.response.v1.json`
+- `schemas/public_api/api.service_accounts.keys.create.request.v1.json`
+- `schemas/public_api/api.service_accounts.keys.create.response.v1.json`
+- `schemas/public_api/api.service_accounts.keys.revoke.response.v1.json`
+
+### Planned Endpoint Mapping
+
+- `POST /v1/service-accounts`
+  - request: `api.service_accounts.create.request.v1.json`
+  - response: `api.service_accounts.create.response.v1.json`
+- `GET /v1/service-accounts?org_id=...&workspace_id=...`
+  - response: `api.service_accounts.list.response.v1.json`
+- `GET /v1/service-accounts/{service_account_id}`
+  - response: `api.service_accounts.get.response.v1.json`
+- `POST /v1/service-accounts/{service_account_id}/keys`
+  - request: `api.service_accounts.keys.create.request.v1.json`
+  - response: `api.service_accounts.keys.create.response.v1.json`
+- `POST /v1/service-accounts/{service_account_id}/keys/{key_id}/revoke`
+  - response: `api.service_accounts.keys.revoke.response.v1.json`

--- a/schemas/public_api/api.service_accounts.create.request.v1.json
+++ b/schemas/public_api/api.service_accounts.create.request.v1.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.service_accounts.create.request.v1.json",
+  "title": "ApiServiceAccountsCreateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id",
+    "workspace_id",
+    "name",
+    "created_by_actor_id"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "workspace_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 120
+    },
+    "description": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "created_by_actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    }
+  }
+}

--- a/schemas/public_api/api.service_accounts.create.response.v1.json
+++ b/schemas/public_api/api.service_accounts.create.response.v1.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.service_accounts.create.response.v1.json",
+  "title": "ApiServiceAccountsCreateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "service_account"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "service_account": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "service_account_id",
+        "org_id",
+        "workspace_id",
+        "name",
+        "status",
+        "created_by_actor_id",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "service_account_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 1024
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "suspended",
+            "revoked"
+          ]
+        },
+        "created_by_actor_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.service_accounts.get.response.v1.json
+++ b/schemas/public_api/api.service_accounts.get.response.v1.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.service_accounts.get.response.v1.json",
+  "title": "ApiServiceAccountsGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "service_account"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "service_account": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "service_account_id",
+        "org_id",
+        "workspace_id",
+        "name",
+        "status",
+        "created_by_actor_id",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "service_account_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 120
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 1024
+        },
+        "status": {
+          "type": "string"
+        },
+        "created_by_actor_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.service_accounts.keys.create.request.v1.json
+++ b/schemas/public_api/api.service_accounts.keys.create.request.v1.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.service_accounts.keys.create.request.v1.json",
+  "title": "ApiServiceAccountsKeysCreateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "created_by_actor_id"
+  ],
+  "properties": {
+    "created_by_actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "expires_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    }
+  }
+}

--- a/schemas/public_api/api.service_accounts.keys.create.response.v1.json
+++ b/schemas/public_api/api.service_accounts.keys.create.response.v1.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.service_accounts.keys.create.response.v1.json",
+  "title": "ApiServiceAccountsKeysCreateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "key"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "key": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key_id",
+        "service_account_id",
+        "key_hint",
+        "status",
+        "created_at",
+        "token"
+      ],
+      "properties": {
+        "key_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "service_account_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "key_hint": {
+          "type": "string",
+          "minLength": 4
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active"
+          ]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "token": {
+          "type": "string",
+          "minLength": 12
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.service_accounts.keys.revoke.response.v1.json
+++ b/schemas/public_api/api.service_accounts.keys.revoke.response.v1.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.service_accounts.keys.revoke.response.v1.json",
+  "title": "ApiServiceAccountsKeysRevokeResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "key"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "key": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "service_account_id",
+        "key_id",
+        "status",
+        "revoked_at"
+      ],
+      "properties": {
+        "service_account_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "key_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "revoked"
+          ]
+        },
+        "revoked_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.service_accounts.list.response.v1.json
+++ b/schemas/public_api/api.service_accounts.list.response.v1.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.service_accounts.list.response.v1.json",
+  "title": "ApiServiceAccountsListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "service_accounts"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "service_accounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "service_account_id",
+          "org_id",
+          "workspace_id",
+          "name",
+          "status",
+          "created_by_actor_id",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "service_account_id": {
+            "type": "string",
+            "minLength": 3
+          },
+          "org_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "workspace_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 120
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 1024
+          },
+          "status": {
+            "type": "string"
+          },
+          "created_by_actor_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add canonical public API schemas for service-account create/list/get and key create/revoke families
- publish Track F Phase 2 schema/index mapping for service-account lifecycle endpoints
- align contract source for gateway, SDKs, and conformance checks

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python scripts/validate_schemas.py`
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q tests`

Made with [Cursor](https://cursor.com)