### PR TITLE
feat: add Track F phase3 schemas for routing and deliveries

### DIFF
--- a/docs/public-api-schema-index.md
+++ b/docs/public-api-schema-index.md
@@ -284,3 +284,79 @@ Related artifacts:
   - response: `api.service_accounts.keys.create.response.v1.json`
 - `POST /v1/service-accounts/{service_account_id}/keys/{key_id}/revoke`
   - response: `api.service_accounts.keys.revoke.response.v1.json`
+
+## Track F Phase 3 Naming, Routing, Transports, Deliveries Families (Draft Contracts)
+
+### Files
+
+- `schemas/public_api/api.principals.create.request.v1.json`
+- `schemas/public_api/api.principals.create.response.v1.json`
+- `schemas/public_api/api.principals.get.response.v1.json`
+- `schemas/public_api/api.aliases.bind.request.v1.json`
+- `schemas/public_api/api.aliases.bind.response.v1.json`
+- `schemas/public_api/api.aliases.list.response.v1.json`
+- `schemas/public_api/api.aliases.revoke.response.v1.json`
+- `schemas/public_api/api.aliases.resolve.response.v1.json`
+- `schemas/public_api/api.routing.endpoints.register.request.v1.json`
+- `schemas/public_api/api.routing.endpoints.register.response.v1.json`
+- `schemas/public_api/api.routing.endpoints.list.response.v1.json`
+- `schemas/public_api/api.routing.endpoints.update.request.v1.json`
+- `schemas/public_api/api.routing.endpoints.update.response.v1.json`
+- `schemas/public_api/api.routing.endpoints.remove.response.v1.json`
+- `schemas/public_api/api.routing.resolve.request.v1.json`
+- `schemas/public_api/api.routing.resolve.response.v1.json`
+- `schemas/public_api/api.transports.bindings.upsert.request.v1.json`
+- `schemas/public_api/api.transports.bindings.upsert.response.v1.json`
+- `schemas/public_api/api.transports.bindings.list.response.v1.json`
+- `schemas/public_api/api.transports.bindings.remove.response.v1.json`
+- `schemas/public_api/api.deliveries.submit.request.v1.json`
+- `schemas/public_api/api.deliveries.submit.response.v1.json`
+- `schemas/public_api/api.deliveries.list.response.v1.json`
+- `schemas/public_api/api.deliveries.get.response.v1.json`
+- `schemas/public_api/api.deliveries.replay.response.v1.json`
+
+### Planned Endpoint Mapping
+
+- `POST /v1/principals`
+  - request: `api.principals.create.request.v1.json`
+  - response: `api.principals.create.response.v1.json`
+- `GET /v1/principals/{principal_id}`
+  - response: `api.principals.get.response.v1.json`
+- `POST /v1/aliases`
+  - request: `api.aliases.bind.request.v1.json`
+  - response: `api.aliases.bind.response.v1.json`
+- `GET /v1/aliases`
+  - response: `api.aliases.list.response.v1.json`
+- `POST /v1/aliases/{alias_id}/revoke`
+  - response: `api.aliases.revoke.response.v1.json`
+- `GET /v1/aliases/resolve?org_id=...&workspace_id=...&alias=...`
+  - response: `api.aliases.resolve.response.v1.json`
+- `POST /v1/routing/endpoints`
+  - request: `api.routing.endpoints.register.request.v1.json`
+  - response: `api.routing.endpoints.register.response.v1.json`
+- `GET /v1/routing/endpoints`
+  - response: `api.routing.endpoints.list.response.v1.json`
+- `PATCH /v1/routing/endpoints/{route_id}`
+  - request: `api.routing.endpoints.update.request.v1.json`
+  - response: `api.routing.endpoints.update.response.v1.json`
+- `DELETE /v1/routing/endpoints/{route_id}`
+  - response: `api.routing.endpoints.remove.response.v1.json`
+- `POST /v1/routing/resolve`
+  - request: `api.routing.resolve.request.v1.json`
+  - response: `api.routing.resolve.response.v1.json`
+- `POST /v1/transports/bindings`
+  - request: `api.transports.bindings.upsert.request.v1.json`
+  - response: `api.transports.bindings.upsert.response.v1.json`
+- `GET /v1/transports/bindings`
+  - response: `api.transports.bindings.list.response.v1.json`
+- `DELETE /v1/transports/bindings/{binding_id}`
+  - response: `api.transports.bindings.remove.response.v1.json`
+- `POST /v1/deliveries`
+  - request: `api.deliveries.submit.request.v1.json`
+  - response: `api.deliveries.submit.response.v1.json`
+- `GET /v1/deliveries`
+  - response: `api.deliveries.list.response.v1.json`
+- `GET /v1/deliveries/{delivery_id}`
+  - response: `api.deliveries.get.response.v1.json`
+- `POST /v1/deliveries/{delivery_id}/replay`
+  - response: `api.deliveries.replay.response.v1.json`

--- a/schemas/public_api/api.aliases.bind.request.v1.json
+++ b/schemas/public_api/api.aliases.bind.request.v1.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.aliases.bind.request.v1.json",
+  "title": "ApiAliasesBindRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "principal_id",
+    "alias",
+    "alias_type"
+  ],
+  "properties": {
+    "principal_id": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 64
+    },
+    "alias": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "alias_type": {
+      "type": "string",
+      "enum": [
+        "communication",
+        "service",
+        "external"
+      ]
+    },
+    "metadata": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/public_api/api.aliases.bind.response.v1.json
+++ b/schemas/public_api/api.aliases.bind.response.v1.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.aliases.bind.response.v1.json",
+  "title": "ApiAliasesBindResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "alias"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "alias": {
+      "$ref": "#/$defs/alias"
+    }
+  },
+  "$defs": {
+    "alias": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "alias_id",
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "alias",
+        "alias_type",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at",
+        "revoked_at"
+      ],
+      "properties": {
+        "alias_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "alias": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "alias_type": {
+          "type": "string",
+          "enum": [
+            "communication",
+            "service",
+            "external"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "revoked"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revoked_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.aliases.list.response.v1.json
+++ b/schemas/public_api/api.aliases.list.response.v1.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.aliases.list.response.v1.json",
+  "title": "ApiAliasesListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "aliases"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "aliases": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/alias"
+      }
+    }
+  },
+  "$defs": {
+    "alias": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "alias_id",
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "alias",
+        "alias_type",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at",
+        "revoked_at"
+      ],
+      "properties": {
+        "alias_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "alias": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "alias_type": {
+          "type": "string",
+          "enum": [
+            "communication",
+            "service",
+            "external"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "revoked"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revoked_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.aliases.resolve.response.v1.json
+++ b/schemas/public_api/api.aliases.resolve.response.v1.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.aliases.resolve.response.v1.json",
+  "title": "ApiAliasesResolveResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "resolution"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "resolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "alias",
+        "principal"
+      ],
+      "properties": {
+        "alias": {
+          "$ref": "#/$defs/alias"
+        },
+        "principal": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "principal_id",
+            "principal_type",
+            "status"
+          ],
+          "properties": {
+            "principal_id": {
+              "type": "string",
+              "minLength": 3
+            },
+            "principal_type": {
+              "type": "string",
+              "enum": [
+                "user",
+                "service_agent",
+                "service_account"
+              ]
+            },
+            "display_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "minLength": 1,
+              "maxLength": 255
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "active",
+                "suspended",
+                "inactive"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "alias": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "alias_id",
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "alias",
+        "alias_type",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at",
+        "revoked_at"
+      ],
+      "properties": {
+        "alias_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "alias": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "alias_type": {
+          "type": "string",
+          "enum": [
+            "communication",
+            "service",
+            "external"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "revoked"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revoked_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.aliases.revoke.response.v1.json
+++ b/schemas/public_api/api.aliases.revoke.response.v1.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.aliases.revoke.response.v1.json",
+  "title": "ApiAliasesRevokeResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "alias"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "alias": {
+      "$ref": "#/$defs/alias"
+    }
+  },
+  "$defs": {
+    "alias": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "alias_id",
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "alias",
+        "alias_type",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at",
+        "revoked_at"
+      ],
+      "properties": {
+        "alias_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "alias": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "alias_type": {
+          "type": "string",
+          "enum": [
+            "communication",
+            "service",
+            "external"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "revoked"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revoked_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.deliveries.get.response.v1.json
+++ b/schemas/public_api/api.deliveries.get.response.v1.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.deliveries.get.response.v1.json",
+  "title": "ApiDeliveriesGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "delivery"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "delivery": {
+      "$ref": "#/$defs/delivery"
+    }
+  },
+  "$defs": {
+    "delivery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "delivery_id",
+        "replay_of_delivery_id",
+        "org_id",
+        "workspace_id",
+        "principal_id",
+        "alias",
+        "transport_type",
+        "route_id",
+        "status",
+        "correlation_id",
+        "idempotency_key",
+        "payload",
+        "error_detail",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "delivery_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "replay_of_delivery_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "transport_type": {
+          "type": "string",
+          "enum": [
+            "matrix",
+            "http",
+            "queue",
+            "webhook"
+          ]
+        },
+        "route_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "submitted",
+            "delivered",
+            "failed",
+            "pending",
+            "dead_lettered"
+          ]
+        },
+        "correlation_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "idempotency_key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 4,
+          "maxLength": 255
+        },
+        "payload": {
+          "type": "object"
+        },
+        "error_detail": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.deliveries.list.response.v1.json
+++ b/schemas/public_api/api.deliveries.list.response.v1.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.deliveries.list.response.v1.json",
+  "title": "ApiDeliveriesListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "deliveries"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "deliveries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/delivery"
+      }
+    }
+  },
+  "$defs": {
+    "delivery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "delivery_id",
+        "replay_of_delivery_id",
+        "org_id",
+        "workspace_id",
+        "principal_id",
+        "alias",
+        "transport_type",
+        "route_id",
+        "status",
+        "correlation_id",
+        "idempotency_key",
+        "payload",
+        "error_detail",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "delivery_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "replay_of_delivery_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "transport_type": {
+          "type": "string",
+          "enum": [
+            "matrix",
+            "http",
+            "queue",
+            "webhook"
+          ]
+        },
+        "route_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "submitted",
+            "delivered",
+            "failed",
+            "pending",
+            "dead_lettered"
+          ]
+        },
+        "correlation_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "idempotency_key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 4,
+          "maxLength": 255
+        },
+        "payload": {
+          "type": "object"
+        },
+        "error_detail": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.deliveries.replay.response.v1.json
+++ b/schemas/public_api/api.deliveries.replay.response.v1.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.deliveries.replay.response.v1.json",
+  "title": "ApiDeliveriesReplayResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "delivery"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "delivery": {
+      "$ref": "#/$defs/delivery"
+    }
+  },
+  "$defs": {
+    "delivery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "delivery_id",
+        "replay_of_delivery_id",
+        "org_id",
+        "workspace_id",
+        "principal_id",
+        "alias",
+        "transport_type",
+        "route_id",
+        "status",
+        "correlation_id",
+        "idempotency_key",
+        "payload",
+        "error_detail",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "delivery_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "replay_of_delivery_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "transport_type": {
+          "type": "string",
+          "enum": [
+            "matrix",
+            "http",
+            "queue",
+            "webhook"
+          ]
+        },
+        "route_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "submitted",
+            "delivered",
+            "failed",
+            "pending",
+            "dead_lettered"
+          ]
+        },
+        "correlation_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "idempotency_key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 4,
+          "maxLength": 255
+        },
+        "payload": {
+          "type": "object"
+        },
+        "error_detail": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.deliveries.submit.request.v1.json
+++ b/schemas/public_api/api.deliveries.submit.request.v1.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.deliveries.submit.request.v1.json",
+  "title": "ApiDeliveriesSubmitRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id",
+    "workspace_id",
+    "payload"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "workspace_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "alias": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "principal_id": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 64
+    },
+    "correlation_id": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "idempotency_key": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 255
+    }
+  },
+  "anyOf": [
+    {
+      "required": [
+        "alias"
+      ]
+    },
+    {
+      "required": [
+        "principal_id"
+      ]
+    }
+  ]
+}

--- a/schemas/public_api/api.deliveries.submit.response.v1.json
+++ b/schemas/public_api/api.deliveries.submit.response.v1.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.deliveries.submit.response.v1.json",
+  "title": "ApiDeliveriesSubmitResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "delivery"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "delivery": {
+      "$ref": "#/$defs/delivery"
+    }
+  },
+  "$defs": {
+    "delivery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "delivery_id",
+        "replay_of_delivery_id",
+        "org_id",
+        "workspace_id",
+        "principal_id",
+        "alias",
+        "transport_type",
+        "route_id",
+        "status",
+        "correlation_id",
+        "idempotency_key",
+        "payload",
+        "error_detail",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "delivery_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "replay_of_delivery_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "transport_type": {
+          "type": "string",
+          "enum": [
+            "matrix",
+            "http",
+            "queue",
+            "webhook"
+          ]
+        },
+        "route_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "submitted",
+            "delivered",
+            "failed",
+            "pending",
+            "dead_lettered"
+          ]
+        },
+        "correlation_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3,
+          "maxLength": 255
+        },
+        "idempotency_key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 4,
+          "maxLength": 255
+        },
+        "payload": {
+          "type": "object"
+        },
+        "error_detail": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.principals.create.request.v1.json
+++ b/schemas/public_api/api.principals.create.request.v1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.principals.create.request.v1.json",
+  "title": "ApiPrincipalsCreateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id",
+    "workspace_id",
+    "principal_type"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "workspace_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "principal_type": {
+      "type": "string",
+      "enum": [
+        "user",
+        "service_agent",
+        "service_account"
+      ]
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "metadata": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/public_api/api.principals.create.response.v1.json
+++ b/schemas/public_api/api.principals.create.response.v1.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.principals.create.response.v1.json",
+  "title": "ApiPrincipalsCreateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "principal"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "principal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "principal_type",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "principal_type": {
+          "type": "string",
+          "enum": [
+            "user",
+            "service_agent",
+            "service_account"
+          ]
+        },
+        "display_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "suspended",
+            "inactive"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.principals.get.response.v1.json
+++ b/schemas/public_api/api.principals.get.response.v1.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.principals.get.response.v1.json",
+  "title": "ApiPrincipalsGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "principal"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "principal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "principal_type",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "principal_type": {
+          "type": "string",
+          "enum": [
+            "user",
+            "service_agent",
+            "service_account"
+          ]
+        },
+        "display_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "suspended",
+            "inactive"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.routing.endpoints.list.response.v1.json
+++ b/schemas/public_api/api.routing.endpoints.list.response.v1.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.routing.endpoints.list.response.v1.json",
+  "title": "ApiRoutingEndpointsListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "routes"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/route"
+      }
+    }
+  },
+  "$defs": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "route_id",
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "transport_type",
+        "endpoint_url",
+        "auth_mode",
+        "failover_policy",
+        "priority",
+        "health_status",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "route_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "transport_type": {
+          "type": "string",
+          "enum": [
+            "matrix",
+            "http",
+            "queue",
+            "webhook"
+          ]
+        },
+        "endpoint_url": {
+          "type": "string",
+          "minLength": 8
+        },
+        "auth_mode": {
+          "type": "string",
+          "enum": [
+            "mtls",
+            "jwt",
+            "signed_key",
+            "none"
+          ]
+        },
+        "region": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 64
+        },
+        "cluster_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 128
+        },
+        "failover_policy": {
+          "type": "string",
+          "enum": [
+            "none",
+            "same_region",
+            "cross_region"
+          ]
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "health_status": {
+          "type": "string",
+          "enum": [
+            "healthy",
+            "degraded",
+            "unhealthy",
+            "unknown"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "inactive",
+            "draining"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.routing.endpoints.register.request.v1.json
+++ b/schemas/public_api/api.routing.endpoints.register.request.v1.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.routing.endpoints.register.request.v1.json",
+  "title": "ApiRoutingEndpointsRegisterRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "principal_id",
+    "transport_type",
+    "endpoint_url",
+    "auth_mode"
+  ],
+  "properties": {
+    "principal_id": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 64
+    },
+    "transport_type": {
+      "type": "string",
+      "enum": [
+        "matrix",
+        "http",
+        "queue",
+        "webhook"
+      ]
+    },
+    "endpoint_url": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 4096
+    },
+    "auth_mode": {
+      "type": "string",
+      "enum": [
+        "mtls",
+        "jwt",
+        "signed_key",
+        "none"
+      ]
+    },
+    "region": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 64
+    },
+    "cluster_id": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 128
+    },
+    "failover_policy": {
+      "type": "string",
+      "enum": [
+        "none",
+        "same_region",
+        "cross_region"
+      ]
+    },
+    "priority": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "metadata": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/public_api/api.routing.endpoints.register.response.v1.json
+++ b/schemas/public_api/api.routing.endpoints.register.response.v1.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.routing.endpoints.register.response.v1.json",
+  "title": "ApiRoutingEndpointsRegisterResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "route"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "route": {
+      "$ref": "#/$defs/route"
+    }
+  },
+  "$defs": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "route_id",
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "transport_type",
+        "endpoint_url",
+        "auth_mode",
+        "failover_policy",
+        "priority",
+        "health_status",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "route_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "transport_type": {
+          "type": "string",
+          "enum": [
+            "matrix",
+            "http",
+            "queue",
+            "webhook"
+          ]
+        },
+        "endpoint_url": {
+          "type": "string",
+          "minLength": 8
+        },
+        "auth_mode": {
+          "type": "string",
+          "enum": [
+            "mtls",
+            "jwt",
+            "signed_key",
+            "none"
+          ]
+        },
+        "region": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 64
+        },
+        "cluster_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 128
+        },
+        "failover_policy": {
+          "type": "string",
+          "enum": [
+            "none",
+            "same_region",
+            "cross_region"
+          ]
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "health_status": {
+          "type": "string",
+          "enum": [
+            "healthy",
+            "degraded",
+            "unhealthy",
+            "unknown"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "inactive",
+            "draining"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.routing.endpoints.remove.response.v1.json
+++ b/schemas/public_api/api.routing.endpoints.remove.response.v1.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.routing.endpoints.remove.response.v1.json",
+  "title": "ApiRoutingEndpointsRemoveResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "route"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "route_id",
+        "removed"
+      ],
+      "properties": {
+        "route_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "removed": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.routing.endpoints.update.request.v1.json
+++ b/schemas/public_api/api.routing.endpoints.update.request.v1.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.routing.endpoints.update.request.v1.json",
+  "title": "ApiRoutingEndpointsUpdateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "endpoint_url": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 4096
+    },
+    "auth_mode": {
+      "type": "string",
+      "enum": [
+        "mtls",
+        "jwt",
+        "signed_key",
+        "none"
+      ]
+    },
+    "region": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 64
+    },
+    "cluster_id": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 128
+    },
+    "failover_policy": {
+      "type": "string",
+      "enum": [
+        "none",
+        "same_region",
+        "cross_region"
+      ]
+    },
+    "priority": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "health_status": {
+      "type": "string",
+      "enum": [
+        "healthy",
+        "degraded",
+        "unhealthy",
+        "unknown"
+      ]
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "inactive",
+        "draining"
+      ]
+    },
+    "metadata": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/public_api/api.routing.endpoints.update.response.v1.json
+++ b/schemas/public_api/api.routing.endpoints.update.response.v1.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.routing.endpoints.update.response.v1.json",
+  "title": "ApiRoutingEndpointsUpdateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "route"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "route": {
+      "$ref": "#/$defs/route"
+    }
+  },
+  "$defs": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "route_id",
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "transport_type",
+        "endpoint_url",
+        "auth_mode",
+        "failover_policy",
+        "priority",
+        "health_status",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "route_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "transport_type": {
+          "type": "string",
+          "enum": [
+            "matrix",
+            "http",
+            "queue",
+            "webhook"
+          ]
+        },
+        "endpoint_url": {
+          "type": "string",
+          "minLength": 8
+        },
+        "auth_mode": {
+          "type": "string",
+          "enum": [
+            "mtls",
+            "jwt",
+            "signed_key",
+            "none"
+          ]
+        },
+        "region": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 64
+        },
+        "cluster_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 2,
+          "maxLength": 128
+        },
+        "failover_policy": {
+          "type": "string",
+          "enum": [
+            "none",
+            "same_region",
+            "cross_region"
+          ]
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "health_status": {
+          "type": "string",
+          "enum": [
+            "healthy",
+            "degraded",
+            "unhealthy",
+            "unknown"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "inactive",
+            "draining"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.routing.resolve.request.v1.json
+++ b/schemas/public_api/api.routing.resolve.request.v1.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.routing.resolve.request.v1.json",
+  "title": "ApiRoutingResolveRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id",
+    "workspace_id"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "workspace_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "alias": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 255
+    },
+    "principal_id": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 64
+    }
+  },
+  "anyOf": [
+    {
+      "required": [
+        "alias"
+      ]
+    },
+    {
+      "required": [
+        "principal_id"
+      ]
+    }
+  ]
+}

--- a/schemas/public_api/api.routing.resolve.response.v1.json
+++ b/schemas/public_api/api.routing.resolve.response.v1.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.routing.resolve.response.v1.json",
+  "title": "ApiRoutingResolveResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "resolution"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "resolution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "alias",
+        "principal",
+        "selected_route",
+        "candidate_routes",
+        "resolver_chain"
+      ],
+      "properties": {
+        "alias": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "principal": {
+          "$ref": "#/$defs/principal"
+        },
+        "selected_route": {
+          "$ref": "#/$defs/route"
+        },
+        "candidate_routes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/route"
+          }
+        },
+        "resolver_chain": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "const": [
+            "alias",
+            "principal_id",
+            "endpoint_route",
+            "transport_dispatch"
+          ]
+        }
+      }
+    }
+  },
+  "$defs": {
+    "principal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "principal_type",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "principal_type": {
+          "type": "string"
+        },
+        "display_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "route_id",
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "transport_type",
+        "endpoint_url",
+        "auth_mode",
+        "failover_policy",
+        "priority",
+        "health_status",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "route_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "transport_type": {
+          "type": "string",
+          "enum": [
+            "matrix",
+            "http",
+            "queue",
+            "webhook"
+          ]
+        },
+        "endpoint_url": {
+          "type": "string",
+          "minLength": 8
+        },
+        "auth_mode": {
+          "type": "string",
+          "enum": [
+            "mtls",
+            "jwt",
+            "signed_key",
+            "none"
+          ]
+        },
+        "region": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cluster_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "failover_policy": {
+          "type": "string",
+          "enum": [
+            "none",
+            "same_region",
+            "cross_region"
+          ]
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "health_status": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.transports.bindings.list.response.v1.json
+++ b/schemas/public_api/api.transports.bindings.list.response.v1.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.transports.bindings.list.response.v1.json",
+  "title": "ApiTransportsBindingsListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "bindings"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "bindings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/binding"
+      }
+    }
+  },
+  "$defs": {
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "binding_id",
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "transport_type",
+        "transport_handle",
+        "priority",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "binding_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "transport_type": {
+          "type": "string",
+          "enum": [
+            "matrix",
+            "http",
+            "queue",
+            "webhook"
+          ]
+        },
+        "transport_handle": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 255
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "inactive"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.transports.bindings.remove.response.v1.json
+++ b/schemas/public_api/api.transports.bindings.remove.response.v1.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.transports.bindings.remove.response.v1.json",
+  "title": "ApiTransportsBindingsRemoveResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "binding"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "binding_id",
+        "removed"
+      ],
+      "properties": {
+        "binding_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "removed": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.transports.bindings.upsert.request.v1.json
+++ b/schemas/public_api/api.transports.bindings.upsert.request.v1.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.transports.bindings.upsert.request.v1.json",
+  "title": "ApiTransportsBindingsUpsertRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "principal_id",
+    "transport_type",
+    "transport_handle"
+  ],
+  "properties": {
+    "principal_id": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 64
+    },
+    "transport_type": {
+      "type": "string",
+      "enum": [
+        "matrix",
+        "http",
+        "queue",
+        "webhook"
+      ]
+    },
+    "transport_handle": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 255
+    },
+    "priority": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "inactive"
+      ]
+    },
+    "metadata": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/public_api/api.transports.bindings.upsert.response.v1.json
+++ b/schemas/public_api/api.transports.bindings.upsert.response.v1.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.transports.bindings.upsert.response.v1.json",
+  "title": "ApiTransportsBindingsUpsertResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "binding"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "binding": {
+      "$ref": "#/$defs/binding"
+    }
+  },
+  "$defs": {
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "binding_id",
+        "principal_id",
+        "org_id",
+        "workspace_id",
+        "transport_type",
+        "transport_handle",
+        "priority",
+        "status",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "binding_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "transport_type": {
+          "type": "string",
+          "enum": [
+            "matrix",
+            "http",
+            "queue",
+            "webhook"
+          ]
+        },
+        "transport_handle": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 255
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "inactive"
+          ]
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add public API schemas for Track F phase3 families: principals, aliases, routing endpoints, routing resolve, transport bindings, and deliveries
- define request/response contracts for submit/list/get/replay and endpoint lifecycle operations
- update public API schema index with endpoint mapping for the new families

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q` (in `axme-spec`)

Made with [Cursor](https://cursor.com)