### PR TITLE
feat: add Track F billing plan and invoice schemas

### DIFF
--- a/docs/public-api-schema-index.md
+++ b/docs/public-api-schema-index.md
@@ -285,6 +285,28 @@ Related artifacts:
 - `POST /v1/service-accounts/{service_account_id}/keys/{key_id}/revoke`
   - response: `api.service_accounts.keys.revoke.response.v1.json`
 
+## Track F Phase 2 Billing Families (Draft Contracts)
+
+### Files
+
+- `schemas/public_api/api.billing.plan.update.request.v1.json`
+- `schemas/public_api/api.billing.plan.update.response.v1.json`
+- `schemas/public_api/api.billing.plan.get.response.v1.json`
+- `schemas/public_api/api.billing.invoices.list.response.v1.json`
+- `schemas/public_api/api.billing.invoices.get.response.v1.json`
+
+### Planned Endpoint Mapping
+
+- `PATCH /v1/billing/plan`
+  - request: `api.billing.plan.update.request.v1.json`
+  - response: `api.billing.plan.update.response.v1.json`
+- `GET /v1/billing/plan?org_id=...&workspace_id=...`
+  - response: `api.billing.plan.get.response.v1.json`
+- `GET /v1/billing/invoices?org_id=...&workspace_id=...`
+  - response: `api.billing.invoices.list.response.v1.json`
+- `GET /v1/billing/invoices/{invoice_id}`
+  - response: `api.billing.invoices.get.response.v1.json`
+
 ## Track F Phase 3 Naming, Routing, Transports, Deliveries Families (Draft Contracts)
 
 ### Files

--- a/schemas/public_api/api.billing.invoices.get.response.v1.json
+++ b/schemas/public_api/api.billing.invoices.get.response.v1.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.billing.invoices.get.response.v1.json",
+  "title": "ApiBillingInvoicesGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "invoice"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "invoice": {
+      "$ref": "#/$defs/invoice"
+    }
+  },
+  "$defs": {
+    "invoice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "invoice_id",
+        "org_id",
+        "workspace_id",
+        "billing_plan_id",
+        "period_start",
+        "period_end",
+        "subtotal_minor",
+        "total_minor",
+        "currency",
+        "status",
+        "due_at",
+        "issued_at",
+        "paid_at",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "invoice_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "billing_plan_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        },
+        "period_start": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "period_end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subtotal_minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "currency": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 16
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "issued",
+            "paid",
+            "overdue",
+            "void"
+          ]
+        },
+        "due_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "issued_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "paid_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.billing.invoices.list.response.v1.json
+++ b/schemas/public_api/api.billing.invoices.list.response.v1.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.billing.invoices.list.response.v1.json",
+  "title": "ApiBillingInvoicesListResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "invoices"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "invoices": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/invoice"
+      }
+    }
+  },
+  "$defs": {
+    "invoice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "invoice_id",
+        "org_id",
+        "workspace_id",
+        "billing_plan_id",
+        "period_start",
+        "period_end",
+        "subtotal_minor",
+        "total_minor",
+        "currency",
+        "status",
+        "due_at",
+        "issued_at",
+        "paid_at",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "invoice_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "billing_plan_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 3
+        },
+        "period_start": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "period_end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subtotal_minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "currency": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 16
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "issued",
+            "paid",
+            "overdue",
+            "void"
+          ]
+        },
+        "due_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "issued_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "paid_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.billing.plan.get.response.v1.json
+++ b/schemas/public_api/api.billing.plan.get.response.v1.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.billing.plan.get.response.v1.json",
+  "title": "ApiBillingPlanGetResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "billing_plan"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "billing_plan": {
+      "$ref": "#/$defs/billing_plan"
+    }
+  },
+  "$defs": {
+    "billing_plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "billing_plan_id",
+        "org_id",
+        "workspace_id",
+        "plan_code",
+        "currency",
+        "billing_cycle",
+        "monthly_commit_minor",
+        "seats_included",
+        "overage_unit_price_minor",
+        "status",
+        "updated_by_actor_id",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "billing_plan_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "plan_code": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 64
+        },
+        "currency": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 16
+        },
+        "billing_cycle": {
+          "type": "string",
+          "enum": [
+            "monthly",
+            "annual"
+          ]
+        },
+        "monthly_commit_minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "seats_included": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "overage_unit_price_minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "suspended",
+            "inactive"
+          ]
+        },
+        "updated_by_actor_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schemas/public_api/api.billing.plan.update.request.v1.json
+++ b/schemas/public_api/api.billing.plan.update.request.v1.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.billing.plan.update.request.v1.json",
+  "title": "ApiBillingPlanUpdateRequestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "org_id",
+    "workspace_id",
+    "plan_code",
+    "currency",
+    "billing_cycle",
+    "monthly_commit_minor",
+    "overage_unit_price_minor",
+    "updated_by_actor_id"
+  ],
+  "properties": {
+    "org_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "workspace_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "plan_code": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 64
+    },
+    "currency": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 16
+    },
+    "billing_cycle": {
+      "type": "string",
+      "enum": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "monthly_commit_minor": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "seats_included": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "overage_unit_price_minor": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "updated_by_actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+    },
+    "metadata": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/public_api/api.billing.plan.update.response.v1.json
+++ b/schemas/public_api/api.billing.plan.update.response.v1.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://axme.dev/schemas/public_api/api.billing.plan.update.response.v1.json",
+  "title": "ApiBillingPlanUpdateResponseV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "ok",
+    "billing_plan"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "const": true
+    },
+    "billing_plan": {
+      "$ref": "#/$defs/billing_plan"
+    }
+  },
+  "$defs": {
+    "billing_plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "billing_plan_id",
+        "org_id",
+        "workspace_id",
+        "plan_code",
+        "currency",
+        "billing_cycle",
+        "monthly_commit_minor",
+        "seats_included",
+        "overage_unit_price_minor",
+        "status",
+        "updated_by_actor_id",
+        "metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "properties": {
+        "billing_plan_id": {
+          "type": "string",
+          "minLength": 3
+        },
+        "org_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "workspace_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "plan_code": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 64
+        },
+        "currency": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 16
+        },
+        "billing_cycle": {
+          "type": "string",
+          "enum": [
+            "monthly",
+            "annual"
+          ]
+        },
+        "monthly_commit_minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "seats_included": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "overage_unit_price_minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "suspended",
+            "inactive"
+          ]
+        },
+        "updated_by_actor_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Track F billing schema families for plan update/get and invoices list/get
- publish billing endpoint mappings in public API schema index
- close the remaining billing contract parity gap in `axme-spec`

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)