### PR TITLE
Replace alpha access with Quick Start reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,6 @@ pytest
 ## Contributing & Contact
 
 - Schema proposals and breaking-change requests: open an issue with label `schema-proposal`
-- Alpha access: https://cloud.axme.ai/alpha · Contact and suggestions: [hello@axme.ai](mailto:hello@axme.ai)
+- Quick Start: https://cloud.axme.ai/alpha/cli · Contact: [hello@axme.ai](mailto:hello@axme.ai)
 - Security disclosures: see [SECURITY.md](SECURITY.md)
 - Contribution guidelines: [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
- Replace footer "Alpha access" line with concise Quick Start link

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)